### PR TITLE
fix: worker to runnerlib source checkout now works

### DIFF
--- a/coordinator_api/internal/worker/containerd_runner.go
+++ b/coordinator_api/internal/worker/containerd_runner.go
@@ -71,8 +71,9 @@ func (cr *ContainerdRunner) SpawnJob(ctx context.Context, config *JobConfig) (st
 		"--namespace", containerdNamespace,
 		"run",
 		"--name", containerID,
-		"--rm=false", // Don't auto-remove so we can get logs and exit code
+		"--rm=false",      // Don't auto-remove so we can get logs and exit code
 		"--net", "bridge", // Use bridge networking with CNI
+		"--pull", "always", // Always pull to get latest image
 	}
 
 	// Determine working directory

--- a/jobs/build-all.yaml
+++ b/jobs/build-all.yaml
@@ -57,7 +57,9 @@ command: |-
         --frontend dockerfile.v0 \
         --local context="$context" \
         --local dockerfile="$context" \
+        --opt build-arg:CACHEBUST=$(date +%s) \
         --opt filename="$dockerfile" \
+        --no-cache \
         --output type=image,name="$image",push=true
     }
 

--- a/runnerlib/src/source_prep.py
+++ b/runnerlib/src/source_prep.py
@@ -310,7 +310,16 @@ def _prepare_git_source(source_url: str, source_ref: Optional[str], target_path:
     log_stdout(f"Cloning git repository: {source_url}")
 
     # Remove existing source if it exists
+    # First change to a safe directory in case target_path is the current working directory
+    # (which can happen when workdir is set to /job/src)
+    original_cwd = None
     if target_path.exists():
+        try:
+            original_cwd = os.getcwd()
+            # Change to parent directory before removing target
+            os.chdir(target_path.parent)
+        except OSError:
+            pass  # getcwd might fail if cwd was already deleted
         shutil.rmtree(target_path)
 
     try:


### PR DESCRIPTION
This is changes in the worker and runnerlib to make them interop correctly in a containerd based runtime without needing root in the container the worker spawns