### PR TITLE
fix: add log support and move to json formatted logs

### DIFF
--- a/coordinator_api/cmd/logs.go
+++ b/coordinator_api/cmd/logs.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+// LogsCommand retrieves logs for a job from a remote Reactorcide coordinator API
+var LogsCommand = &cli.Command{
+	Name:      "logs",
+	Usage:     "Get logs for a job from a remote Reactorcide coordinator",
+	ArgsUsage: "<job-id>",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "api-url",
+			Aliases: []string{"u"},
+			Usage:   "Coordinator API URL (e.g., http://localhost:6080)",
+			EnvVars: []string{"REACTORCIDE_API_URL"},
+		},
+		&cli.StringFlag{
+			Name:    "token",
+			Aliases: []string{"t"},
+			Usage:   "API token for authentication",
+			EnvVars: []string{"REACTORCIDE_API_TOKEN"},
+		},
+		&cli.StringFlag{
+			Name:    "stream",
+			Aliases: []string{"s"},
+			Value:   "combined",
+			Usage:   "Log stream to retrieve: stdout, stderr, or combined (default)",
+		},
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "Output file (default: stdout)",
+		},
+	},
+	Action: logsAction,
+}
+
+func logsAction(ctx *cli.Context) error {
+	if ctx.NArg() < 1 {
+		return fmt.Errorf("usage: reactorcide logs <job-id>")
+	}
+
+	jobID := ctx.Args().Get(0)
+	apiURL := ctx.String("api-url")
+	token := ctx.String("token")
+	stream := ctx.String("stream")
+	outputFile := ctx.String("output")
+
+	// Validate required flags
+	if apiURL == "" {
+		return fmt.Errorf("API URL is required (use --api-url or REACTORCIDE_API_URL)")
+	}
+
+	// Normalize API URL (remove trailing slash)
+	apiURL = strings.TrimSuffix(apiURL, "/")
+
+	// Validate stream parameter
+	if stream != "stdout" && stream != "stderr" && stream != "combined" {
+		return fmt.Errorf("invalid stream value: %s (must be stdout, stderr, or combined)", stream)
+	}
+
+	// Get API token
+	var err error
+	if token == "" {
+		token, err = promptForSecret("REACTORCIDE_API_TOKEN", "API token: ")
+		if err != nil {
+			return err
+		}
+	}
+
+	if token == "" {
+		return fmt.Errorf("API token is required (use --token or REACTORCIDE_API_TOKEN)")
+	}
+
+	// Fetch logs from API
+	logs, err := fetchJobLogs(apiURL, token, jobID, stream)
+	if err != nil {
+		return fmt.Errorf("failed to fetch logs: %w", err)
+	}
+
+	// Output logs
+	if outputFile != "" {
+		if err := os.WriteFile(outputFile, logs, 0644); err != nil {
+			return fmt.Errorf("failed to write logs to file: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Logs written to: %s\n", outputFile)
+	} else {
+		fmt.Print(string(logs))
+	}
+
+	return nil
+}
+
+// fetchJobLogs retrieves logs for a job from the coordinator API
+func fetchJobLogs(apiURL, token, jobID, stream string) ([]byte, error) {
+	url := fmt.Sprintf("%s/api/v1/jobs/%s/logs", apiURL, jobID)
+	if stream != "" && stream != "combined" {
+		url = fmt.Sprintf("%s?stream=%s", url, stream)
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return body, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("job not found or no logs available for job: %s", jobID)
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("unauthorized: invalid or missing API token")
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("forbidden: you don't have permission to access this job's logs")
+	case http.StatusServiceUnavailable:
+		return nil, fmt.Errorf("service unavailable: object store not configured on the server")
+	default:
+		return nil, fmt.Errorf("API error (%d): %s", resp.StatusCode, string(body))
+	}
+}

--- a/coordinator_api/internal/handlers/base_handler.go
+++ b/coordinator_api/internal/handlers/base_handler.go
@@ -57,6 +57,10 @@ func (h *BaseHandler) respondWithError(w http.ResponseWriter, code int, err erro
 		errType = "unauthorized"
 		message = "Unauthorized"
 		code = http.StatusUnauthorized
+	case errors.Is(err, store.ErrServiceUnavailable):
+		errType = "service_unavailable"
+		message = "Service temporarily unavailable"
+		code = http.StatusServiceUnavailable
 	default:
 		errType = "internal_error"
 		message = "Internal server error"

--- a/coordinator_api/internal/store/store_types.go
+++ b/coordinator_api/internal/store/store_types.go
@@ -7,12 +7,13 @@ const RequestContextKey = "request"
 
 // Common errors that can be returned by any store implementation
 var (
-	ErrNotFound      = errors.New("record not found")
-	ErrInvalidInput  = errors.New("invalid input")
-	ErrAlreadyExists = errors.New("record already exists")
-	ErrInternal      = errors.New("internal error")
-	ErrUnauthorized  = errors.New("unauthorized")
-	ErrForbidden     = errors.New("forbidden") // 403 Forbidden - for permission issues
+	ErrNotFound           = errors.New("record not found")
+	ErrInvalidInput       = errors.New("invalid input")
+	ErrAlreadyExists      = errors.New("record already exists")
+	ErrInternal           = errors.New("internal error")
+	ErrUnauthorized       = errors.New("unauthorized")
+	ErrForbidden          = errors.New("forbidden")           // 403 Forbidden - for permission issues
+	ErrServiceUnavailable = errors.New("service unavailable") // 503 Service Unavailable - for external dependencies
 )
 
 // PaginationParams contains common pagination parameters

--- a/coordinator_api/main.go
+++ b/coordinator_api/main.go
@@ -21,6 +21,7 @@ func main() {
 			cmd.SecretsCommand,
 			cmd.RunLocalCommand,
 			cmd.SubmitCommand,
+			cmd.LogsCommand,
 		},
 	}
 	err := app.Run(os.Args)

--- a/coordinator_api/test/job_logs_test.go
+++ b/coordinator_api/test/job_logs_test.go
@@ -1,0 +1,541 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/catalystcommunity/reactorcide/coordinator_api/internal/handlers"
+	"github.com/catalystcommunity/reactorcide/coordinator_api/internal/objects"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestJobLogsAPI tests the job logs API endpoint
+func TestJobLogsAPI(t *testing.T) {
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns stdout logs", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Create a test job
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Test Job with Logs",
+				"SourceType": "git",
+				"JobCommand": "echo hello",
+				"Status":     "completed",
+			})
+			require.NoError(t, err)
+
+			// Store logs in the memory object store
+			stdoutContent := "Hello from stdout!\nLine 2\nLine 3"
+			stdoutKey := "logs/" + job.JobID + "/stdout.log"
+			err = memStore.Put(ctx, stdoutKey, bytes.NewReader([]byte(stdoutContent)), "text/plain")
+			require.NoError(t, err)
+
+			// Request logs with stream=stdout
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs?stream=stdout", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "text/plain; charset=utf-8", rr.Header().Get("Content-Type"))
+			assert.Equal(t, stdoutContent, rr.Body.String())
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns stderr logs", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Create a test job
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Test Job with Stderr",
+				"SourceType": "git",
+				"JobCommand": "echo error >&2",
+				"Status":     "failed",
+			})
+			require.NoError(t, err)
+
+			// Store stderr logs in the memory object store
+			stderrContent := "Error: Something went wrong\nStack trace here"
+			stderrKey := "logs/" + job.JobID + "/stderr.log"
+			err = memStore.Put(ctx, stderrKey, bytes.NewReader([]byte(stderrContent)), "text/plain")
+			require.NoError(t, err)
+
+			// Request logs with stream=stderr
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs?stream=stderr", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "text/plain; charset=utf-8", rr.Header().Get("Content-Type"))
+			assert.Equal(t, stderrContent, rr.Body.String())
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns combined logs by default", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Create a test job
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Test Job Combined",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+				"Status":     "completed",
+			})
+			require.NoError(t, err)
+
+			// Store both stdout and stderr logs
+			stdoutContent := "Output line 1\nOutput line 2"
+			stderrContent := "Warning: something happened"
+			stdoutKey := "logs/" + job.JobID + "/stdout.log"
+			stderrKey := "logs/" + job.JobID + "/stderr.log"
+
+			err = memStore.Put(ctx, stdoutKey, bytes.NewReader([]byte(stdoutContent)), "text/plain")
+			require.NoError(t, err)
+			err = memStore.Put(ctx, stderrKey, bytes.NewReader([]byte(stderrContent)), "text/plain")
+			require.NoError(t, err)
+
+			// Request logs without stream parameter (should return combined)
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, "text/plain; charset=utf-8", rr.Header().Get("Content-Type"))
+
+			// Combined output should contain both with separator
+			responseBody := rr.Body.String()
+			assert.Contains(t, responseBody, "Output line 1")
+			assert.Contains(t, responseBody, "Output line 2")
+			assert.Contains(t, responseBody, "--- stderr ---")
+			assert.Contains(t, responseBody, "Warning: something happened")
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns 404 when no logs exist", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Create a test job (no logs stored)
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Job Without Logs",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+				"Status":     "submitted",
+			})
+			require.NoError(t, err)
+
+			// Request logs
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusNotFound, rr.Code)
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns 404 for non-existent job", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Request logs for non-existent job
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/nonexistent-job-id/logs", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusNotFound, rr.Code)
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns 401 without auth", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user and job
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Test Job",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+			})
+			require.NoError(t, err)
+
+			// Request logs without auth header
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs", nil)
+			require.NoError(t, err)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rr.Code)
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns 403 for other user's job", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create two users
+			user1, err := dataUtils.CreateUser(DataSetup{
+				"Username": "user1",
+				"Email":    "user1@example.com",
+			})
+			require.NoError(t, err)
+
+			user2, err := dataUtils.CreateUser(DataSetup{
+				"Username": "user2",
+				"Email":    "user2@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header for user2
+			authHeader2, err := createAuthTokenHeader(ctx, tx, user2.UserID)
+			require.NoError(t, err)
+
+			// Create a job for user1
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user1.UserID,
+				"Name":       "User1's Job",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+			})
+			require.NoError(t, err)
+
+			// Store logs for user1's job
+			stdoutContent := "User1's logs"
+			stdoutKey := "logs/" + job.JobID + "/stdout.log"
+			err = memStore.Put(ctx, stdoutKey, bytes.NewReader([]byte(stdoutContent)), "text/plain")
+			require.NoError(t, err)
+
+			// User2 tries to access User1's job logs
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader2)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns 400 for invalid stream parameter", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Create a test job
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Test Job",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+			})
+			require.NoError(t, err)
+
+			// Request logs with invalid stream parameter
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs?stream=invalid", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	})
+
+	t.Run("GET /api/v1/jobs/{job_id}/logs returns only stdout when stderr is missing", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a test user
+			user, err := dataUtils.CreateUser(DataSetup{
+				"Username": "testuser",
+				"Email":    "test@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create auth header
+			authHeader, err := createAuthTokenHeader(ctx, tx, user.UserID)
+			require.NoError(t, err)
+
+			// Create a test job
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     user.UserID,
+				"Name":       "Test Job Stdout Only",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+				"Status":     "completed",
+			})
+			require.NoError(t, err)
+
+			// Only store stdout logs (no stderr)
+			stdoutContent := "Output without errors"
+			stdoutKey := "logs/" + job.JobID + "/stdout.log"
+			err = memStore.Put(ctx, stdoutKey, bytes.NewReader([]byte(stdoutContent)), "text/plain")
+			require.NoError(t, err)
+
+			// Request combined logs (default)
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", authHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, stdoutContent, rr.Body.String())
+			assert.NotContains(t, rr.Body.String(), "--- stderr ---")
+		})
+	})
+}
+
+// TestJobLogsAdminAccess tests that admins can access any user's logs
+func TestJobLogsAdminAccess(t *testing.T) {
+	t.Run("admin can access other user's job logs", func(t *testing.T) {
+		RunTransactionalTest(t, func(ctx context.Context, tx *gorm.DB) {
+			// Create and set up a memory object store for this test
+			memStore := objects.NewMemoryObjectStore()
+			handlers.SetObjectStore(memStore)
+			defer handlers.SetObjectStore(nil)
+
+			// Reset app mux to pick up the new object store
+			handlers.ResetAppMux()
+			mux := handlers.GetAppMux()
+
+			dataUtils := &DataUtils{db: tx}
+
+			// Create a regular user
+			regularUser, err := dataUtils.CreateUser(DataSetup{
+				"Username": "regularuser",
+				"Email":    "regular@example.com",
+			})
+			require.NoError(t, err)
+
+			// Create an admin user
+			adminUser, err := dataUtils.CreateUser(DataSetup{
+				"Username": "adminuser",
+				"Email":    "admin@example.com",
+				"Roles":    []string{"admin"},
+			})
+			require.NoError(t, err)
+
+			// Create auth header for admin
+			tokenValue := "test-api-token-" + adminUser.UserID
+			tokenHash := sha256.Sum256([]byte(tokenValue))
+			_, err = dataUtils.CreateAPIToken(DataSetup{
+				"UserID":    adminUser.UserID,
+				"Name":      "Admin Token",
+				"TokenHash": tokenHash[:],
+				"IsActive":  true,
+			})
+			require.NoError(t, err)
+			adminAuthHeader := "Bearer " + tokenValue
+
+			// Create a job for regular user
+			job, err := dataUtils.CreateJob(DataSetup{
+				"UserID":     regularUser.UserID,
+				"Name":       "Regular User's Job",
+				"SourceType": "git",
+				"JobCommand": "echo test",
+				"Status":     "completed",
+			})
+			require.NoError(t, err)
+
+			// Store logs for regular user's job
+			stdoutContent := "Regular user's logs"
+			stdoutKey := "logs/" + job.JobID + "/stdout.log"
+			err = memStore.Put(ctx, stdoutKey, bytes.NewReader([]byte(stdoutContent)), "text/plain")
+			require.NoError(t, err)
+
+			// Admin requests logs for regular user's job
+			req, err := http.NewRequestWithContext(ctx, "GET", "/api/v1/jobs/"+job.JobID+"/logs", nil)
+			require.NoError(t, err)
+			req.Header.Set("Authorization", adminAuthHeader)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assert.Equal(t, stdoutContent, rr.Body.String())
+		})
+	})
+}


### PR DESCRIPTION
This will give us both a CLI command and log endpoint. in the API, and can order logs by timestamp when combining stdout and stderr streams