### PR TITLE
feat: set webhook for github in env vars

### DIFF
--- a/deployment/deploy-vm.sh
+++ b/deployment/deploy-vm.sh
@@ -109,6 +109,9 @@ REACTORCIDE_LOG_LEVEL=${REACTORCIDE_LOG_LEVEL:-info}
 # Master keys format: name1:base64key1,name2:base64key2 (first is primary)
 REACTORCIDE_SECRETS_STORAGE_TYPE=database
 REACTORCIDE_MASTER_KEYS=${REACTORCIDE_MASTER_KEYS}
+
+# VCS webhook secret for GitHub signature validation
+REACTORCIDE_VCS_GITHUB_SECRET=${REACTORCIDE_VCS_GITHUB_SECRET:-}
 ENVFILE
 
 echo "Environment configuration created"

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -88,6 +88,8 @@ services:
       # Secrets management (database storage enabled by default)
       REACTORCIDE_SECRETS_STORAGE_TYPE: ${REACTORCIDE_SECRETS_STORAGE_TYPE:-database}
       REACTORCIDE_MASTER_KEYS: ${REACTORCIDE_MASTER_KEYS:-}
+      # VCS webhook secret for GitHub signature validation
+      REACTORCIDE_VCS_GITHUB_SECRET: ${REACTORCIDE_VCS_GITHUB_SECRET:-}
     ports:
       - "6080:6080"
     volumes:

--- a/helm_chart/templates/deployment-app.yaml
+++ b/helm_chart/templates/deployment-app.yaml
@@ -114,6 +114,13 @@ spec:
                   name: {{ include "app.secretName" . }}
                   key: REACTORCIDE_MASTER_KEYS
             {{- end }}
+            {{- if .Values.vcs.github.webhookSecret }}
+            - name: REACTORCIDE_VCS_GITHUB_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "app.secretName" . }}
+                  key: REACTORCIDE_VCS_GITHUB_SECRET
+            {{- end }}
             # Default user ID from generated secret
             - name: REACTORCIDE_DEFAULT_USER_ID
               valueFrom:

--- a/helm_chart/templates/secret-app.yaml
+++ b/helm_chart/templates/secret-app.yaml
@@ -26,3 +26,6 @@ data:
   {{- if .Values.secrets.storageType }}
   REACTORCIDE_SECRETS_STORAGE_TYPE: {{ .Values.secrets.storageType | b64enc | quote }}
   {{- end }}
+  {{- if .Values.vcs.github.webhookSecret }}
+  REACTORCIDE_VCS_GITHUB_SECRET: {{ .Values.vcs.github.webhookSecret | b64enc | quote }}
+  {{- end }}

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -215,6 +215,13 @@ secrets:
   existingSecret: ""  # e.g., "reactorcide-master-keys"
   existingSecretKey: "master-keys"  # Key within the existing secret
 
+# VCS (Version Control System) integration
+vcs:
+  github:
+    # HMAC secret for validating GitHub webhook signatures
+    # IMPORTANT: In production, set this via external secret management, not in values.yaml
+    webhookSecret: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/jobs/deploy-to-vm.yaml
+++ b/jobs/deploy-to-vm.yaml
@@ -254,6 +254,9 @@ command: |-
     update_env_var "REACTORCIDE_COORDINATOR_IMAGE" "${REACTORCIDE_COORDINATOR_IMAGE:-}"
     update_env_var "REACTORCIDE_WORKER_IMAGE" "${REACTORCIDE_WORKER_IMAGE:-}"
     update_env_var "REACTORCIDE_RUNNER_IMAGE" "${REACTORCIDE_RUNNER_IMAGE:-}"
+
+    echo "Configuring VCS webhook secrets:"
+    update_env_var "REACTORCIDE_VCS_GITHUB_SECRET" "${REACTORCIDE_VCS_GITHUB_SECRET:-}"
     REMOTE_EOF
 
     echo ""
@@ -394,6 +397,9 @@ environment:
     REACTORCIDE_WORKER_POLL_INTERVAL: "${env:REACTORCIDE_WORKER_POLL_INTERVAL}"
     REACTORCIDE_LOG_LEVEL: "${env:REACTORCIDE_LOG_LEVEL}"
     REACTORCIDE_REMOTE_DIR: "${env:REACTORCIDE_REMOTE_DIR}"
+
+    # VCS webhook secret for GitHub signature validation
+    REACTORCIDE_VCS_GITHUB_SECRET: "${secret:reactorcide/deployment:github_webhook_secret}"
 
     # Container image overrides (for internal registries)
     REACTORCIDE_COORDINATOR_IMAGE: "${env:REACTORCIDE_COORDINATOR_IMAGE}"


### PR DESCRIPTION
This also will deal with the state where none is set and will not validate. Tokenless webhooks should never be a thing.