### PR TITLE
fix: setup run-local mounts the same

### DIFF
--- a/coordinator_api/cmd/run_local_test.go
+++ b/coordinator_api/cmd/run_local_test.go
@@ -303,6 +303,17 @@ func TestToJobConfig(t *testing.T) {
 	if config.Env["REACTORCIDE_JOB_ID"] != "job-123" {
 		t.Errorf("expected REACTORCIDE_JOB_ID=job-123, got %q", config.Env["REACTORCIDE_JOB_ID"])
 	}
+
+	// Check standard container environment variables
+	if config.Env["REACTORCIDE_IN_CONTAINER"] != "true" {
+		t.Errorf("expected REACTORCIDE_IN_CONTAINER=true, got %q", config.Env["REACTORCIDE_IN_CONTAINER"])
+	}
+	if config.Env["REACTORCIDE_CODE_DIR"] != "/job/src" {
+		t.Errorf("expected REACTORCIDE_CODE_DIR=/job/src, got %q", config.Env["REACTORCIDE_CODE_DIR"])
+	}
+	if config.Env["REACTORCIDE_JOB_DIR"] != "/job/src" {
+		t.Errorf("expected REACTORCIDE_JOB_DIR=/job/src, got %q", config.Env["REACTORCIDE_JOB_DIR"])
+	}
 }
 
 func TestJobSpec_WithSource(t *testing.T) {

--- a/coordinator_api/internal/worker/containerd_runner.go
+++ b/coordinator_api/internal/worker/containerd_runner.go
@@ -83,6 +83,9 @@ func (cr *ContainerdRunner) SpawnJob(ctx context.Context, config *JobConfig) (st
 
 	// Mount workspace directory
 	args = append(args, "-v", fmt.Sprintf("%s:/job", config.WorkspaceDir))
+	if config.SourceDir != "" {
+		args = append(args, "-v", fmt.Sprintf("%s:/job/src", config.SourceDir))
+	}
 
 	// Add environment variables
 	for key, value := range config.Env {

--- a/coordinator_api/internal/worker/docker_runner.go
+++ b/coordinator_api/internal/worker/docker_runner.go
@@ -96,6 +96,9 @@ func (dr *DockerRunner) SpawnJob(ctx context.Context, config *JobConfig) (string
 	binds := []string{
 		fmt.Sprintf("%s:/job", config.WorkspaceDir),
 	}
+	if config.SourceDir != "" {
+		binds = append(binds, fmt.Sprintf("%s:/job/src", config.SourceDir))
+	}
 
 	// Handle capabilities
 	privileged := false

--- a/coordinator_api/internal/worker/docker_runner_test.go
+++ b/coordinator_api/internal/worker/docker_runner_test.go
@@ -325,6 +325,33 @@ func TestGetSupportedBackends(t *testing.T) {
 	}
 }
 
+// TestJobConfig_SourceDir tests that SourceDir field is properly set on JobConfig
+func TestJobConfig_SourceDir(t *testing.T) {
+	config := &JobConfig{
+		Image:        "alpine:latest",
+		Command:      []string{"echo", "hello"},
+		WorkspaceDir: "/tmp/workspace",
+		SourceDir:    "/home/user/project",
+		JobID:        "test-123",
+	}
+
+	if config.SourceDir != "/home/user/project" {
+		t.Errorf("SourceDir = %q, want /home/user/project", config.SourceDir)
+	}
+
+	// Validate that SourceDir doesn't affect normal validation
+	runner := &DockerRunner{}
+	if err := runner.validateConfig(config); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+
+	// SourceDir is optional - empty should also pass validation
+	config.SourceDir = ""
+	if err := runner.validateConfig(config); err != nil {
+		t.Errorf("unexpected validation error with empty SourceDir: %v", err)
+	}
+}
+
 // TestContainerdRunner_validateConfig tests the configuration validation for containerd
 func TestContainerdRunner_validateConfig(t *testing.T) {
 	runner := &ContainerdRunner{

--- a/coordinator_api/internal/worker/interfaces.go
+++ b/coordinator_api/internal/worker/interfaces.go
@@ -69,6 +69,10 @@ type JobConfig struct {
 	// WorkspaceDir is the host directory to mount into the container at /job
 	WorkspaceDir string
 
+	// SourceDir is an optional host directory to mount at /job/src in the container.
+	// Used by run-local to mount user's source into the standard production layout.
+	SourceDir string
+
 	// WorkingDir is the working directory inside the container (default: /job)
 	WorkingDir string
 

--- a/coordinator_api/internal/worker/job_spec.go
+++ b/coordinator_api/internal/worker/job_spec.go
@@ -190,6 +190,12 @@ func (s *JobSpec) ToJobConfig(workspaceDir, jobID, queueName string) *JobConfig 
 	// Add triggers file path
 	env["REACTORCIDE_TRIGGERS_FILE"] = "/job/triggers.json"
 
+	// Standard container environment: tell runnerlib it's running inside a container
+	// and where source code is mounted. True for both local and production containers.
+	env["REACTORCIDE_IN_CONTAINER"] = "true"
+	env["REACTORCIDE_CODE_DIR"] = "/job/src"
+	env["REACTORCIDE_JOB_DIR"] = "/job/src"
+
 	config := &JobConfig{
 		Image:          s.Image,
 		Command:        command,

--- a/coordinator_api/internal/worker/job_spec_test.go
+++ b/coordinator_api/internal/worker/job_spec_test.go
@@ -794,6 +794,17 @@ func TestToJobConfig(t *testing.T) {
 		t.Errorf("REACTORCIDE_JOB_ID not set")
 	}
 
+	// Check standard container environment variables
+	if config.Env["REACTORCIDE_IN_CONTAINER"] != "true" {
+		t.Errorf("REACTORCIDE_IN_CONTAINER = %q, want true", config.Env["REACTORCIDE_IN_CONTAINER"])
+	}
+	if config.Env["REACTORCIDE_CODE_DIR"] != "/job/src" {
+		t.Errorf("REACTORCIDE_CODE_DIR = %q, want /job/src", config.Env["REACTORCIDE_CODE_DIR"])
+	}
+	if config.Env["REACTORCIDE_JOB_DIR"] != "/job/src" {
+		t.Errorf("REACTORCIDE_JOB_DIR = %q, want /job/src", config.Env["REACTORCIDE_JOB_DIR"])
+	}
+
 	// Check capabilities
 	if len(config.Capabilities) != 2 {
 		t.Errorf("expected 2 capabilities, got %d", len(config.Capabilities))

--- a/jobs/build-all.yaml
+++ b/jobs/build-all.yaml
@@ -67,30 +67,30 @@ command: |-
     echo ""
     echo ">>> Building runnerbase..."
     echo "----------------------------------------"
-    build_and_push /job/runnerlib Dockerfile.runner "$REGISTRY/public/reactorcide/runnerbase:$TAG"
+    build_and_push /job/src/runnerlib Dockerfile.runner "$REGISTRY/public/reactorcide/runnerbase:$TAG"
 
     # Build Go binary (shared by coordinator and worker)
     echo ""
     echo ">>> Building Go binary..."
     echo "----------------------------------------"
-    cd /job/coordinator_api
+    cd /job/src/coordinator_api
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o reactorcide .
-    cp reactorcide /job/deployment/
+    cp reactorcide /job/src/deployment/
 
     # Build coordinator
     echo ""
     echo ">>> Building coordinator..."
     echo "----------------------------------------"
-    build_and_push /job/deployment Dockerfile.coordinator "$REGISTRY/public/reactorcide/coordinator:$TAG"
+    build_and_push /job/src/deployment Dockerfile.coordinator "$REGISTRY/public/reactorcide/coordinator:$TAG"
 
     # Build worker
     echo ""
     echo ">>> Building worker..."
     echo "----------------------------------------"
-    build_and_push /job/deployment Dockerfile.worker "$REGISTRY/public/reactorcide/worker:$TAG"
+    build_and_push /job/src/deployment Dockerfile.worker "$REGISTRY/public/reactorcide/worker:$TAG"
 
     # Cleanup
-    rm -f /job/deployment/reactorcide
+    rm -f /job/src/deployment/reactorcide
 
     echo ""
     echo "========================================"

--- a/jobs/build-coordinator.yaml
+++ b/jobs/build-coordinator.yaml
@@ -17,15 +17,15 @@ command: |-
 
     # Build the Go binary
     echo "Building reactorcide binary..."
-    cd /job/coordinator_api
+    cd /job/src/coordinator_api
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o reactorcide .
 
     # Copy binary to deployment directory
-    cp reactorcide /job/deployment/
+    cp reactorcide /job/src/deployment/
 
     # Build container image
     echo "Building container image..."
-    cd /job/deployment
+    cd /job/src/deployment
     nerdctl build -t "$REGISTRY/$IMAGE:$TAG" -f Dockerfile.coordinator .
 
     # Login and push
@@ -33,7 +33,7 @@ command: |-
     nerdctl push "$REGISTRY/$IMAGE:$TAG"
 
     # Cleanup
-    rm -f /job/deployment/reactorcide
+    rm -f /job/src/deployment/reactorcide
 
     echo "Done! Image pushed to $REGISTRY/$IMAGE:$TAG"
   '

--- a/jobs/build-runnerbase.yaml
+++ b/jobs/build-runnerbase.yaml
@@ -15,7 +15,7 @@ command: |-
     rm /tmp/nerdctl.tar.gz
 
     # Build image
-    cd /job/runnerlib
+    cd /job/src/runnerlib
     nerdctl build -t "$REGISTRY/$IMAGE:$TAG" -f Dockerfile.runner .
 
     # Login and push

--- a/jobs/build-worker.yaml
+++ b/jobs/build-worker.yaml
@@ -17,15 +17,15 @@ command: |-
 
     # Build the Go binary
     echo "Building reactorcide binary..."
-    cd /job/coordinator_api
+    cd /job/src/coordinator_api
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o reactorcide .
 
     # Copy binary to deployment directory
-    cp reactorcide /job/deployment/
+    cp reactorcide /job/src/deployment/
 
     # Build container image
     echo "Building container image..."
-    cd /job/deployment
+    cd /job/src/deployment
     nerdctl build -t "$REGISTRY/$IMAGE:$TAG" -f Dockerfile.worker .
 
     # Login and push
@@ -33,7 +33,7 @@ command: |-
     nerdctl push "$REGISTRY/$IMAGE:$TAG"
 
     # Cleanup
-    rm -f /job/deployment/reactorcide
+    rm -f /job/src/deployment/reactorcide
 
     echo "Done! Image pushed to $REGISTRY/$IMAGE:$TAG"
   '

--- a/jobs/deploy-to-vm.yaml
+++ b/jobs/deploy-to-vm.yaml
@@ -143,7 +143,7 @@ command: |-
 
     echo ""
     echo "Step 3: Copying deployment files"
-    tar -C /job/deployment -czf - docker-compose.prod.yml nginx.conf | ssh "${REACTORCIDE_DEPLOY_USER}@${REACTORCIDE_DEPLOY_HOST}" "tar -C ${REMOTE_DIR} -xzf -"
+    tar -C /job/src/deployment -czf - docker-compose.prod.yml nginx.conf | ssh "${REACTORCIDE_DEPLOY_USER}@${REACTORCIDE_DEPLOY_HOST}" "tar -C ${REMOTE_DIR} -xzf -"
 
     echo ""
     echo "Step 4: Checking environment configuration on VM"

--- a/jobs/test-runnerlib-job.yaml
+++ b/jobs/test-runnerlib-job.yaml
@@ -11,7 +11,7 @@ command: |
     echo 'Working directory:' \$(pwd)
     echo ''
     echo 'Source checkout contents (top level):'
-    ls -la /job/ | head -20
+    ls -la /job/src/ | head -20
     echo ''
     echo 'Python version:'
     python --version


### PR DESCRIPTION
run-local didn't do the right mounts, but we fixed this in a way that specifically keeps a run-local from having to know it's not in k8s or something, so the behavior is the same in all three deployment types