### PR TITLE
fix: vcs glue 10

### DIFF
--- a/runnerlib/tests/test_eval_cli.py
+++ b/runnerlib/tests/test_eval_cli.py
@@ -650,7 +650,7 @@ class TestEvalEndToEnd:
         assert data["jobs"][0]["env"]["REACTORCIDE_PR_NUMBER"] == "42"
         assert data["jobs"][0]["env"]["PYTEST_ARGS"] == "-v"
         assert data["jobs"][0]["container_image"] == "python:3.11"
-        assert data["jobs"][0]["job_command"] == "pytest"
+        assert data["jobs"][0]["job_command"] == "runnerlib run --job-command 'pytest'"
         assert data["jobs"][0]["timeout"] == 1800
 
     def test_push_to_main_triggers_deploy(self, temp_dirs):


### PR DESCRIPTION
Eval jobs should assume they should be run in runnerlib (unless already being done so), unless the job is specified as a raw_command job. Otherwise, source doesn't get checked out, plugins don't get registered, etc