### PR TITLE
fix: get statuses back to github for PR related jobs

### DIFF
--- a/coordinator_api/internal/handlers/project_handler.go
+++ b/coordinator_api/internal/handlers/project_handler.go
@@ -40,6 +40,8 @@ type CreateProjectRequest struct {
 	DefaultJobCommand     string `json:"default_job_command,omitempty"`
 	DefaultTimeoutSeconds *int   `json:"default_timeout_seconds,omitempty"`
 	DefaultQueueName      string `json:"default_queue_name,omitempty"`
+
+	VCSTokenSecret string `json:"vcs_token_secret,omitempty"`
 }
 
 // UpdateProjectRequest represents the request body for updating a project
@@ -60,6 +62,8 @@ type UpdateProjectRequest struct {
 	DefaultJobCommand     *string `json:"default_job_command,omitempty"`
 	DefaultTimeoutSeconds *int    `json:"default_timeout_seconds,omitempty"`
 	DefaultQueueName      *string `json:"default_queue_name,omitempty"`
+
+	VCSTokenSecret *string `json:"vcs_token_secret,omitempty"`
 }
 
 // ProjectResponse represents the response body for a project
@@ -83,6 +87,8 @@ type ProjectResponse struct {
 	DefaultJobCommand     string `json:"default_job_command,omitempty"`
 	DefaultTimeoutSeconds int    `json:"default_timeout_seconds"`
 	DefaultQueueName      string `json:"default_queue_name"`
+
+	VCSTokenSecret string `json:"vcs_token_secret,omitempty"`
 }
 
 // ListProjectsResponse represents the response body for listing projects
@@ -111,6 +117,7 @@ func projectToResponse(p *models.Project) ProjectResponse {
 		DefaultJobCommand:     p.DefaultJobCommand,
 		DefaultTimeoutSeconds: p.DefaultTimeoutSeconds,
 		DefaultQueueName:      p.DefaultQueueName,
+		VCSTokenSecret:        p.VCSTokenSecret,
 	}
 }
 
@@ -168,6 +175,9 @@ func (h *ProjectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.DefaultQueueName != "" {
 		project.DefaultQueueName = req.DefaultQueueName
+	}
+	if req.VCSTokenSecret != "" {
+		project.VCSTokenSecret = req.VCSTokenSecret
 	}
 
 	if err := h.store.CreateProject(r.Context(), project); err != nil {
@@ -302,6 +312,9 @@ func (h *ProjectHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.DefaultQueueName != nil {
 		project.DefaultQueueName = *req.DefaultQueueName
+	}
+	if req.VCSTokenSecret != nil {
+		project.VCSTokenSecret = *req.VCSTokenSecret
 	}
 
 	if err := h.store.UpdateProject(r.Context(), project); err != nil {

--- a/coordinator_api/internal/store/models/project.go
+++ b/coordinator_api/internal/store/models/project.go
@@ -37,6 +37,9 @@ type Project struct {
 	DefaultCISourceURL  string     `gorm:"type:text" json:"default_ci_source_url"`
 	DefaultCISourceRef  string     `gorm:"type:text;default:'main'" json:"default_ci_source_ref"`
 
+	// VCS integration — stores a "path:key" reference into the secrets store
+	VCSTokenSecret string `gorm:"type:text" json:"vcs_token_secret"`
+
 	// Job defaults
 	DefaultRunnerImage     string `gorm:"type:text;default:'quay.io/catalystcommunity/reactorcide_runner'" json:"default_runner_image"`
 	DefaultJobCommand      string `gorm:"type:text" json:"default_job_command"`

--- a/coordinator_api/internal/vcs/manager.go
+++ b/coordinator_api/internal/vcs/manager.go
@@ -132,6 +132,27 @@ func (m *Manager) GetWebhookSecret() string {
 	return ""
 }
 
+// CreateClientWithToken creates a new VCS client for the given provider
+// using a per-project token instead of the global token.
+func (m *Manager) CreateClientWithToken(provider Provider, token string) (Client, error) {
+	switch provider {
+	case GitHub:
+		return NewGitHubClient(Config{
+			Provider: GitHub,
+			Token:    token,
+			BaseURL:  m.baseURL,
+		})
+	case GitLab:
+		return NewGitLabClient(Config{
+			Provider: GitLab,
+			Token:    token,
+			BaseURL:  m.baseURL,
+		})
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
+}
+
 // GetClients returns all configured VCS clients
 func (m *Manager) GetClients() map[Provider]Client {
 	return m.clients

--- a/coordinator_api/internal/worker/trigger_processor.go
+++ b/coordinator_api/internal/worker/trigger_processor.go
@@ -226,6 +226,11 @@ func (tp *TriggerProcessor) buildJobFromTrigger(spec triggerJobSpec, parentJob *
 		job.EventMetadata = parentJob.EventMetadata
 	}
 
+	// Copy VCS metadata (Notes) so child jobs can report commit status
+	if parentJob.Notes != "" {
+		job.Notes = parentJob.Notes
+	}
+
 	return job
 }
 

--- a/coredb/migrations/000010_vcs_token_secret.sql
+++ b/coredb/migrations/000010_vcs_token_secret.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- Add per-project VCS token secret reference for multi-org deployments.
+-- Stores a "path:key" reference into the secrets store.
+ALTER TABLE projects ADD COLUMN vcs_token_secret text;
+
+-- +goose Down
+ALTER TABLE projects DROP COLUMN IF EXISTS vcs_token_secret;


### PR DESCRIPTION
In theory this allows github status checks to work, which we'll test and/or fix with semver-tags as the guinea pig