### PR TITLE
fix: per-project webhook secrets instead of global

### DIFF
--- a/coordinator_api/internal/config/config.go
+++ b/coordinator_api/internal/config/config.go
@@ -37,13 +37,10 @@ var (
 	ObjectStorePrefix   = env.GetEnvOrDefault("REACTORCIDE_OBJECT_STORE_PREFIX", "reactorcide/") // for s3/gcs
 
 	// VCS Integration configuration
-	VCSGitHubToken   = env.GetEnvOrDefault("REACTORCIDE_VCS_GITHUB_TOKEN", "")
-	VCSGitHubSecret  = env.GetEnvOrDefault("REACTORCIDE_VCS_GITHUB_SECRET", "")
-	VCSGitLabToken   = env.GetEnvOrDefault("REACTORCIDE_VCS_GITLAB_TOKEN", "")
-	VCSGitLabSecret  = env.GetEnvOrDefault("REACTORCIDE_VCS_GITLAB_SECRET", "")
-	VCSWebhookSecret = env.GetEnvOrDefault("REACTORCIDE_VCS_WEBHOOK_SECRET", "") // Shared secret for all providers
-	VCSEnabled       = env.GetEnvAsBoolOrDefault("REACTORCIDE_VCS_ENABLED", "false")
-	VCSBaseURL       = env.GetEnvOrDefault("REACTORCIDE_VCS_BASE_URL", "https://reactorcide.example.com") // Base URL for status links
+	VCSGitHubToken = env.GetEnvOrDefault("REACTORCIDE_VCS_GITHUB_TOKEN", "")
+	VCSGitLabToken = env.GetEnvOrDefault("REACTORCIDE_VCS_GITLAB_TOKEN", "")
+	VCSEnabled     = env.GetEnvAsBoolOrDefault("REACTORCIDE_VCS_ENABLED", "false")
+	VCSBaseURL     = env.GetEnvOrDefault("REACTORCIDE_VCS_BASE_URL", "https://reactorcide.example.com") // Base URL for status links
 
 	// CI Code Security configuration
 	CiCodeAllowlist = env.GetEnvOrDefault("REACTORCIDE_CI_CODE_ALLOWLIST", "")

--- a/coordinator_api/internal/handlers/project_handler.go
+++ b/coordinator_api/internal/handlers/project_handler.go
@@ -42,6 +42,7 @@ type CreateProjectRequest struct {
 	DefaultQueueName      string `json:"default_queue_name,omitempty"`
 
 	VCSTokenSecret string `json:"vcs_token_secret,omitempty"`
+	WebhookSecret  string `json:"webhook_secret,omitempty"`
 }
 
 // UpdateProjectRequest represents the request body for updating a project
@@ -64,6 +65,7 @@ type UpdateProjectRequest struct {
 	DefaultQueueName      *string `json:"default_queue_name,omitempty"`
 
 	VCSTokenSecret *string `json:"vcs_token_secret,omitempty"`
+	WebhookSecret  *string `json:"webhook_secret,omitempty"`
 }
 
 // ProjectResponse represents the response body for a project
@@ -89,6 +91,7 @@ type ProjectResponse struct {
 	DefaultQueueName      string `json:"default_queue_name"`
 
 	VCSTokenSecret string `json:"vcs_token_secret,omitempty"`
+	WebhookSecret  string `json:"webhook_secret,omitempty"`
 }
 
 // ListProjectsResponse represents the response body for listing projects
@@ -118,6 +121,7 @@ func projectToResponse(p *models.Project) ProjectResponse {
 		DefaultTimeoutSeconds: p.DefaultTimeoutSeconds,
 		DefaultQueueName:      p.DefaultQueueName,
 		VCSTokenSecret:        p.VCSTokenSecret,
+		WebhookSecret:         p.WebhookSecret,
 	}
 }
 
@@ -178,6 +182,9 @@ func (h *ProjectHandler) CreateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.VCSTokenSecret != "" {
 		project.VCSTokenSecret = req.VCSTokenSecret
+	}
+	if req.WebhookSecret != "" {
+		project.WebhookSecret = req.WebhookSecret
 	}
 
 	if err := h.store.CreateProject(r.Context(), project); err != nil {
@@ -315,6 +322,9 @@ func (h *ProjectHandler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.VCSTokenSecret != nil {
 		project.VCSTokenSecret = *req.VCSTokenSecret
+	}
+	if req.WebhookSecret != nil {
+		project.WebhookSecret = *req.WebhookSecret
 	}
 
 	if err := h.store.UpdateProject(r.Context(), project); err != nil {

--- a/coordinator_api/internal/handlers/router.go
+++ b/coordinator_api/internal/handlers/router.go
@@ -98,9 +98,6 @@ func createAppMux() *http.ServeMux {
 	for provider, client := range vcsManager.GetClients() {
 		webhookHandler.AddVCSClient(provider, client)
 	}
-	if secret := vcsManager.GetWebhookSecret(); secret != "" {
-		webhookHandler.SetWebhookSecret(secret)
-	}
 
 	// Wire per-project VCS token resolution into webhook handler.
 	// Deferred until after the key manager is initialized below.

--- a/coordinator_api/internal/store/models/project.go
+++ b/coordinator_api/internal/store/models/project.go
@@ -37,8 +37,12 @@ type Project struct {
 	DefaultCISourceURL  string     `gorm:"type:text" json:"default_ci_source_url"`
 	DefaultCISourceRef  string     `gorm:"type:text;default:'main'" json:"default_ci_source_ref"`
 
-	// VCS integration — stores a "path:key" reference into the secrets store
+	// VCS integration — stores "path:key" references into the secrets store
 	VCSTokenSecret string `gorm:"type:text" json:"vcs_token_secret"`
+	// WebhookSecret stores a "path:key" reference to the webhook signing secret
+	// for this project. When set, incoming webhooks are validated using this
+	// per-project secret instead of the global REACTORCIDE_VCS_GITHUB_SECRET.
+	WebhookSecret string `gorm:"type:text" json:"webhook_secret"`
 
 	// Job defaults
 	DefaultRunnerImage     string `gorm:"type:text;default:'quay.io/catalystcommunity/reactorcide_runner'" json:"default_runner_image"`

--- a/coordinator_api/internal/vcs/github_test.go
+++ b/coordinator_api/internal/vcs/github_test.go
@@ -344,7 +344,6 @@ func TestGitHubClient_ParseWebhook_FormEncoded(t *testing.T) {
 func TestGitHubClient_ValidateWebhook(t *testing.T) {
 	client, err := NewGitHubClient(Config{
 		Provider:      GitHub,
-		WebhookSecret: "test-secret",
 	})
 	require.NoError(t, err)
 

--- a/coordinator_api/internal/vcs/interface.go
+++ b/coordinator_api/internal/vcs/interface.go
@@ -130,10 +130,9 @@ type Client interface {
 
 // Config holds VCS configuration
 type Config struct {
-	Provider     Provider
-	Token        string // API token for status updates
-	WebhookSecret string // Secret for webhook validation
-	BaseURL      string // Base URL for Enterprise instances (optional)
+	Provider Provider
+	Token    string // API token for status updates
+	BaseURL  string // Base URL for Enterprise instances (optional)
 }
 
 // NewClient creates a new VCS client based on the provider


### PR DESCRIPTION
This makes multitenant more feasible, though I'm sure we'll also need an org-level when we have it integrated more with the IDP we haven't written yet.