### PR TITLE
fix: let github use dirs owned by root

### DIFF
--- a/coordinator_api/internal/worker/kubernetes_runner.go
+++ b/coordinator_api/internal/worker/kubernetes_runner.go
@@ -103,12 +103,19 @@ func (kr *KubernetesRunner) SpawnJob(ctx context.Context, config *JobConfig) (st
 	workingDir := config.WorkingDir
 
 	// Build environment variables
-	envVars := make([]corev1.EnvVar, 0, len(config.Env)+1)
+	envVars := make([]corev1.EnvVar, 0, len(config.Env)+4)
 	// Set HOME to a writable directory so tools (git, go, etc.) work under UID 1001
 	envVars = append(envVars, corev1.EnvVar{
 		Name:  "HOME",
 		Value: "/home/reactorcide",
 	})
+	// Mark all directories as git safe.directory so git works when emptyDir
+	// mount points are root-owned but the process runs as UID 1001
+	envVars = append(envVars,
+		corev1.EnvVar{Name: "GIT_CONFIG_COUNT", Value: "1"},
+		corev1.EnvVar{Name: "GIT_CONFIG_KEY_0", Value: "safe.directory"},
+		corev1.EnvVar{Name: "GIT_CONFIG_VALUE_0", Value: "*"},
+	)
 	for key, value := range config.Env {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  key,


### PR DESCRIPTION
The workspace dir is mounted as root, but we run as 1001 by default, so...