### PR TITLE
fix: prevent newlines in docker auth config in release

### DIFF
--- a/.reactorcide/jobs/scripts/release.sh
+++ b/.reactorcide/jobs/scripts/release.sh
@@ -45,7 +45,7 @@ cat > /home/reactorcide/.docker/config.json <<DOCKEREOF
 {
   "auths": {
     "${REGISTRY}": {
-      "auth": "$(echo -n "${REGISTRY_USER}:${REGISTRY_PASSWORD}" | base64)"
+      "auth": "$(echo -n "${REGISTRY_USER}:${REGISTRY_PASSWORD}" | base64 -w 0)"
     }
   }
 }


### PR DESCRIPTION
what it says on the tin