### PR TITLE
fix: setup third party pr refs for forks

### DIFF
--- a/.reactorcide/jobs/conventional-commits.yaml
+++ b/.reactorcide/jobs/conventional-commits.yaml
@@ -10,8 +10,16 @@ job:
   image: 10.16.0.1:5000/public/reactorcide/runnerbase:dev
   command: |
     set -e
-    git clone --branch "${REACTORCIDE_PR_REF}" "${REACTORCIDE_SOURCE_URL}" /job/src
+    # SOURCE_URL points at the fork for cross-repo PRs (where the branch
+    # actually lives); HEAD_URL is the same value, named for clarity. BASE_URL
+    # is the upstream — we add it as a second remote so `git log base..HEAD`
+    # works even when the fork doesn't have the upstream's tip.
+    git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /job/src
     cd /job/src
+    if [ -n "${REACTORCIDE_BASE_URL}" ] && [ "${REACTORCIDE_BASE_URL}" != "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" ]; then
+      git remote add upstream "${REACTORCIDE_BASE_URL}"
+      git fetch upstream "${REACTORCIDE_BASE_REF:-$REACTORCIDE_PR_BASE_REF}"
+    fi
 
     echo "=== Validating Conventional Commits ==="
     PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'

--- a/.reactorcide/jobs/test-go.yaml
+++ b/.reactorcide/jobs/test-go.yaml
@@ -8,7 +8,9 @@ job:
     if [ "${REACTORCIDE_WORKER_MODE:-remote}" = "local" ]; then
       cd /job/src/coordinator_api
     else
-      git clone --branch "${REACTORCIDE_PR_REF}" "${REACTORCIDE_SOURCE_URL}" /workspace
+      # HEAD_URL points at the fork for cross-repo PRs; falls back to
+      # SOURCE_URL for back-compat with older worker versions.
+      git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /workspace
       cd /workspace/coordinator_api
     fi
     echo "=== Running Go Tests ==="

--- a/.reactorcide/jobs/test-python.yaml
+++ b/.reactorcide/jobs/test-python.yaml
@@ -8,7 +8,9 @@ job:
       cd /job/src/runnerlib
     else
       git config --global init.defaultBranch main
-      git clone --branch "${REACTORCIDE_PR_REF}" "${REACTORCIDE_SOURCE_URL}" /workspace
+      # HEAD_URL points at the fork for cross-repo PRs; falls back to
+      # SOURCE_URL for back-compat with older worker versions.
+      git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /workspace
       cd /workspace/runnerlib
     fi
     echo "=== Running Python Tests ==="

--- a/.reactorcide/jobs/test-web.yaml
+++ b/.reactorcide/jobs/test-web.yaml
@@ -8,7 +8,9 @@ job:
     if [ "${REACTORCIDE_WORKER_MODE:-remote}" = "local" ]; then
       cd /job/src/webapp
     else
-      git clone --branch "${REACTORCIDE_PR_REF}" "${REACTORCIDE_SOURCE_URL}" /workspace
+      # HEAD_URL points at the fork for cross-repo PRs; falls back to
+      # SOURCE_URL for back-compat with older worker versions.
+      git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /workspace
       cd /workspace/webapp
     fi
     echo "=== Running Web UI Unit Tests ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,56 @@ Use cases:
 | Environment | Passed directly | Managed by runnerlib with secret resolution |
 | Output handling | Basic stdout/stderr | Structured logs with masking |
 
+### Fork PRs and Cross-Repo Code Sources
+
+Reactorcide distinguishes two sources for a job:
+
+- **Code source** (`SourceURL`/`SourceRef`): the code being checked out at `/job/src`. For a PR opened from a fork, this points at the **fork** — that's where the branch lives.
+- **CI source** (`CISourceURL`/`CISourceRef`): the trusted location of CI definitions (`.reactorcide/jobs/*.yaml`). Always upstream — never the fork. Fork content is never executed as a CI definition.
+
+Environment variables made available to jobs:
+
+| Variable | Meaning |
+|---|---|
+| `REACTORCIDE_SOURCE_URL` | Code-source URL. For fork PRs, this is the fork's clone URL. |
+| `REACTORCIDE_HEAD_URL` | Explicit head repo URL (same as `SOURCE_URL` for PRs; convenience). |
+| `REACTORCIDE_HEAD_REF` | PR head branch name. |
+| `REACTORCIDE_BASE_URL` | Upstream/base repo URL. Useful for jobs that need both remotes (e.g. `git log base..head`). |
+| `REACTORCIDE_BASE_REF` | PR target branch. |
+| `REACTORCIDE_IS_FORK_PR` | `"true"` when the PR head lives on a different repo than the base. |
+| `REACTORCIDE_CI_SOURCE_URL` | Always upstream (or `project.DefaultCISourceURL`). Never the fork. |
+| `REACTORCIDE_CI_SOURCE_REF` | For PRs, the base branch SHA. For pushes, the pushed SHA. |
+| `REACTORCIDE_PR_REF`, `REACTORCIDE_PR_BASE_REF`, `REACTORCIDE_PR_NUMBER` | Back-compat: kept for older job YAMLs. |
+
+For a raw-command job that needs both remotes (e.g. to inspect commits added by the PR), the recommended pattern is:
+
+```bash
+git clone --branch "${REACTORCIDE_HEAD_REF}" "${REACTORCIDE_HEAD_URL}" /job/src
+cd /job/src
+git remote add upstream "${REACTORCIDE_BASE_URL}"
+git fetch upstream "${REACTORCIDE_BASE_REF}"
+# Now `git log upstream/${REACTORCIDE_BASE_REF}..HEAD` works for fork PRs too.
+```
+
+Jobs that wrap their command with `runnerlib run` automatically get both remotes set up — runnerlib reads `REACTORCIDE_BASE_URL`/`BASE_REF` during source preparation and adds `upstream` to the clone when the base differs from the cloned origin.
+
+#### Testing a fork PR locally
+
+Run-local supports cloning an arbitrary code source instead of bind-mounting your working copy:
+
+```bash
+# Test a specific URL + ref
+./coordinator_api/reactorcide run-local \
+  --code-url https://github.com/fork-owner/repo.git \
+  --code-ref lilac/text-overflow \
+  .reactorcide/jobs/conventional-commits.yaml
+
+# Resolve a PR via the GitHub CLI (requires `gh` and a cwd inside the target repo)
+./coordinator_api/reactorcide run-local --pr 60 .reactorcide/jobs/conventional-commits.yaml
+```
+
+Both flags clone into a tempdir, mount it at `/job/src`, and set the same `REACTORCIDE_*` env vars the worker would set for a fork PR — so jobs behave identically locally and remotely. When neither flag is set, run-local bind-mounts `--job-dir` (your local working copy) as before.
+
 ## Project Status
 
 The system is actively being developed with the core runnerlib functionality complete and the coordinator API providing job management capabilities. Join the [Catalyst Community Discord](https://discord.gg/sfNb9xRjPn) to discuss and contribute.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -49,10 +49,14 @@ This separation enables flexibility in deployment models: from running jobs loca
 ### 1. Decoupled Job Definition and Execution
 **Critical Distinction**: The code that **defines the CI/CD job** is separate from the code being **tested/built**.
 
-- **Job Code**: Scripts, configuration, pipeline definitions (can be in separate repo)
-- **Source Code**: The application code being tested (PR code, branch code, etc.)
+- **Job Code** (`CISourceURL`/`CISourceRef`): Scripts, configuration, pipeline definitions (can be in separate repo)
+- **Source Code** (`SourceURL`/`SourceRef`): The application code being tested (PR code, branch code, fork code, etc.)
 - **Default**: By default, job and source are the same repo (simple path)
-- **Security Model**: For untrusted contributions, job code comes from a trusted repo while source code comes from the PR
+- **Security Model**: For untrusted contributions, job code comes from a trusted location while source code can come from anywhere — including a PR opened from a fork.
+
+**Fork PR specifics.** When a PR is opened from a fork, `SourceURL` points at the **fork** (where the branch lives) and `CISourceURL` points at the **upstream** at the trusted base SHA. Fork content is never executed as a CI definition. A malicious PR cannot ship a modified `.reactorcide/jobs/*.yaml` and have it run — the eval job loads CI from the base branch's last trusted commit. Run-local mirrors this model: `--code-url` / `--pr` clone an arbitrary code source into `/job/src`, while the CI definitions remain whatever YAML the user explicitly passed on the command line.
+
+**Unified run-local / worker model.** Run-local is the canonical execution path: a job declares what code it needs, and the executor provides it. Locally that means either bind-mounting your working copy (default) or cloning the requested source. Remotely, the worker performs the same bootstrap before invoking the job. The same `REACTORCIDE_HEAD_URL` / `BASE_URL` env vars are populated in both modes so job scripts behave identically.
 
 This enables secure execution of CI/CD jobs against untrusted code contributions.
 

--- a/coordinator_api/cmd/run_local.go
+++ b/coordinator_api/cmd/run_local.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -92,8 +94,181 @@ var RunLocalCommand = &cli.Command{
 			Name:  "allow-secret-overrides",
 			Usage: "Allow overlays to override secret references with plaintext values",
 		},
+		&cli.StringFlag{
+			Name:  "code-url",
+			Usage: "Git URL to clone into /job/src instead of bind-mounting --job-dir. Used together with --code-ref to test arbitrary code (e.g. a fork branch) locally.",
+		},
+		&cli.StringFlag{
+			Name:  "code-ref",
+			Usage: "Git ref (branch, tag, or SHA) to checkout from --code-url. Defaults to the remote's default branch.",
+		},
+		&cli.IntFlag{
+			Name:  "pr",
+			Usage: "GitHub PR number to test. Resolves the head repo and branch via `gh pr view`, then behaves like --code-url / --code-ref. Requires `gh` on PATH and the cwd to be inside a github checkout. Mutually exclusive with --code-url.",
+		},
 	},
 	Action: runLocalAction,
+}
+
+// resolvedCodeSource holds what --code-url / --code-ref / --pr resolve to. A
+// nil value means run-local should fall back to its default behavior of
+// bind-mounting --job-dir at /job/src.
+type resolvedCodeSource struct {
+	URL       string
+	Ref       string
+	HeadRef   string // branch name (== Ref when Ref is a branch; used for HEAD_REF env)
+	BaseURL   string // upstream URL when PR is cross-repo, empty otherwise
+	BaseRef   string // base branch when known
+	PRNumber  int    // 0 when not from --pr
+	IsForkPR  bool
+}
+
+// resolveCodeSource turns the user's --code-url / --code-ref / --pr flags
+// into a resolvedCodeSource, or returns nil when none were set. Errors on
+// mutually-exclusive combinations or when --pr resolution fails.
+func resolveCodeSource(ctx *cli.Context) (*resolvedCodeSource, error) {
+	return resolveCodeSourceFromArgs(ctx.String("code-url"), ctx.String("code-ref"), ctx.Int("pr"))
+}
+
+// resolveCodeSourceFromArgs is the pure-function core of resolveCodeSource,
+// extracted so it can be unit tested without constructing a cli.Context.
+func resolveCodeSourceFromArgs(codeURL, codeRef string, prNum int) (*resolvedCodeSource, error) {
+	if prNum != 0 && codeURL != "" {
+		return nil, fmt.Errorf("--pr and --code-url are mutually exclusive")
+	}
+
+	if codeURL != "" {
+		return &resolvedCodeSource{
+			URL:     codeURL,
+			Ref:     codeRef,
+			HeadRef: codeRef,
+		}, nil
+	}
+
+	if prNum != 0 {
+		return resolvePRViaGH(prNum)
+	}
+
+	return nil, nil
+}
+
+// resolvePRViaGH shells out to `gh pr view` from the cwd to discover the
+// PR's head/base repos and branches. Returns a friendly error if `gh` is
+// missing or the cwd isn't a recognizable GitHub checkout.
+func resolvePRViaGH(prNum int) (*resolvedCodeSource, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, fmt.Errorf("--pr requires the `gh` CLI on PATH; install it from https://cli.github.com or use --code-url instead")
+	}
+
+	cmd := exec.Command("gh", "pr", "view", strconv.Itoa(prNum),
+		"--json", "headRefName,headRefOid,baseRefName,isCrossRepository,headRepository,headRepositoryOwner,baseRepository")
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		return nil, fmt.Errorf("`gh pr view %d` failed: %w (stderr: %s) — run from inside a checkout of the PR's target repo, or use --code-url", prNum, err, stderr)
+	}
+
+	var pr struct {
+		HeadRefName         string `json:"headRefName"`
+		HeadRefOid          string `json:"headRefOid"`
+		BaseRefName         string `json:"baseRefName"`
+		IsCrossRepository   bool   `json:"isCrossRepository"`
+		HeadRepository      struct {
+			Name          string `json:"name"`
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"headRepository"`
+		HeadRepositoryOwner struct {
+			Login string `json:"login"`
+		} `json:"headRepositoryOwner"`
+		BaseRepository struct {
+			Name          string `json:"name"`
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"baseRepository"`
+	}
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return nil, fmt.Errorf("could not parse `gh pr view` output: %w", err)
+	}
+
+	// `gh pr view` returns Name for head/base repos but not always a full
+	// nameWithOwner; fall back to combining owner + name when needed.
+	headOwner := pr.HeadRepositoryOwner.Login
+	headNameWithOwner := pr.HeadRepository.NameWithOwner
+	if headNameWithOwner == "" && headOwner != "" && pr.HeadRepository.Name != "" {
+		headNameWithOwner = headOwner + "/" + pr.HeadRepository.Name
+	}
+	if headNameWithOwner == "" {
+		return nil, fmt.Errorf("`gh pr view %d` returned no head repository info", prNum)
+	}
+	baseNameWithOwner := pr.BaseRepository.NameWithOwner
+	if baseNameWithOwner == "" {
+		// Best effort: derive from `gh repo view`.
+		if rc, err := exec.Command("gh", "repo", "view", "--json", "nameWithOwner").Output(); err == nil {
+			var rv struct {
+				NameWithOwner string `json:"nameWithOwner"`
+			}
+			_ = json.Unmarshal(rc, &rv)
+			baseNameWithOwner = rv.NameWithOwner
+		}
+	}
+
+	src := &resolvedCodeSource{
+		URL:      fmt.Sprintf("https://github.com/%s.git", headNameWithOwner),
+		Ref:      pr.HeadRefName,
+		HeadRef:  pr.HeadRefName,
+		BaseRef:  pr.BaseRefName,
+		PRNumber: prNum,
+		IsForkPR: pr.IsCrossRepository,
+	}
+	if baseNameWithOwner != "" {
+		src.BaseURL = fmt.Sprintf("https://github.com/%s.git", baseNameWithOwner)
+	}
+	return src, nil
+}
+
+// cloneCodeSource clones src.URL@src.Ref into a fresh tempdir and returns the
+// tempdir path plus a cleanup func the caller must defer.
+func cloneCodeSource(src *resolvedCodeSource, uid, gid int) (string, func(), error) {
+	tmp, err := os.MkdirTemp("/tmp", "reactorcide-local-code-")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("failed to create temp dir for --code-url checkout: %w", err)
+	}
+	cleanup := func() { os.RemoveAll(tmp) }
+
+	args := []string{"clone"}
+	if src.Ref != "" {
+		args = append(args, "--branch", src.Ref)
+	}
+	args = append(args, src.URL, tmp)
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("git clone failed for %s @ %s: %w", src.URL, src.Ref, err)
+	}
+
+	// If a base URL was supplied (cross-repo PR) and it differs from the
+	// cloned URL, add it as `upstream` and fetch the base ref. This mirrors
+	// what runnerlib's _checkout_with_fetch_fallback does for the worker.
+	if src.BaseURL != "" && src.BaseURL != src.URL {
+		if err := exec.Command("git", "-C", tmp, "remote", "add", "upstream", src.BaseURL).Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to add upstream remote %s: %v\n", src.BaseURL, err)
+		} else if src.BaseRef != "" {
+			if err := exec.Command("git", "-C", tmp, "fetch", "upstream", src.BaseRef).Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to fetch upstream/%s: %v\n", src.BaseRef, err)
+			}
+		}
+	}
+
+	// Match ownership to the container's run-as user.
+	_ = filepath.Walk(tmp, func(path string, _ os.FileInfo, _ error) error {
+		_ = os.Chown(path, uid, gid)
+		return nil
+	})
+	return tmp, cleanup, nil
 }
 
 func runLocalAction(ctx *cli.Context) error {
@@ -107,6 +282,11 @@ func runLocalAction(ctx *cli.Context) error {
 	backend := ctx.String("backend")
 	inputFiles := ctx.StringSlice("input")
 	allowSecretOverrides := ctx.Bool("allow-secret-overrides")
+
+	codeSource, err := resolveCodeSource(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Load job specification with overlays
 	spec, secretOverrides, err := worker.LoadJobSpecWithOverlays(jobFile, inputFiles)
@@ -218,10 +398,52 @@ func runLocalAction(ctx *cli.Context) error {
 		return fmt.Errorf("failed to chown workspace src dir: %w", err)
 	}
 
+	// Resolve what to mount at /job/src:
+	//   - default: --job-dir (the user's local working copy)
+	//   - --code-url / --pr: clone into a tempdir, mount that instead
+	srcMount := absJobDir
+	if codeSource != nil {
+		fmt.Printf("Code source: cloning %s @ %s\n", codeSource.URL, codeSource.Ref)
+		if spec.Source != nil && spec.Source.Type != "" && spec.Source.Type != "none" {
+			fmt.Fprintf(os.Stderr,
+				"Notice: job spec declares source.%s but --code-url/--pr overrides it.\n",
+				spec.Source.Type,
+			)
+		}
+		codeDir, cleanup, err := cloneCodeSource(codeSource, uid, gid)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		srcMount = codeDir
+
+		// Populate the same env vars the worker would set so the job
+		// behaves identically whether run locally or remotely.
+		spec.Environment["REACTORCIDE_SOURCE_URL"] = codeSource.URL
+		spec.Environment["REACTORCIDE_HEAD_URL"] = codeSource.URL
+		if codeSource.HeadRef != "" {
+			spec.Environment["REACTORCIDE_HEAD_REF"] = codeSource.HeadRef
+			spec.Environment["REACTORCIDE_PR_REF"] = codeSource.HeadRef
+		}
+		if codeSource.BaseURL != "" {
+			spec.Environment["REACTORCIDE_BASE_URL"] = codeSource.BaseURL
+		}
+		if codeSource.BaseRef != "" {
+			spec.Environment["REACTORCIDE_BASE_REF"] = codeSource.BaseRef
+			spec.Environment["REACTORCIDE_PR_BASE_REF"] = codeSource.BaseRef
+		}
+		if codeSource.IsForkPR {
+			spec.Environment["REACTORCIDE_IS_FORK_PR"] = "true"
+		}
+		if codeSource.PRNumber > 0 {
+			spec.Environment["REACTORCIDE_PR_NUMBER"] = strconv.Itoa(codeSource.PRNumber)
+		}
+	}
+
 	// Convert spec to JobConfig using temp workspace, then set SourceDir
-	// so the runner mounts the user's source at /job/src
+	// so the runner mounts the resolved source at /job/src.
 	jobConfig := spec.ToJobConfig(tempWorkspace, jobID, "local")
-	jobConfig.SourceDir = absJobDir
+	jobConfig.SourceDir = srcMount
 	jobConfig.RunAsUser = fmt.Sprintf("%d:%d", uid, gid)
 
 	// Synthesize a minimal /etc/passwd and /etc/group so tools that require a
@@ -269,7 +491,7 @@ func runLocalAction(ctx *cli.Context) error {
 	}
 
 	if dryRun {
-		return performLocalDryRun(spec, jobConfig, masker, absJobDir)
+		return performLocalDryRun(spec, jobConfig, masker, srcMount)
 	}
 
 	// Create the job runner

--- a/coordinator_api/cmd/run_local_test.go
+++ b/coordinator_api/cmd/run_local_test.go
@@ -350,6 +350,79 @@ source:
 	}
 }
 
+func TestResolveCodeSourceFromArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		codeURL     string
+		codeRef     string
+		prNum       int
+		wantNil     bool
+		wantErr     bool
+		wantURL     string
+		wantRef     string
+		wantHeadRef string
+	}{
+		{
+			name:    "no flags returns nil",
+			wantNil: true,
+		},
+		{
+			name:        "code-url alone resolves",
+			codeURL:     "https://github.com/fork-owner/repo.git",
+			codeRef:     "lilac/text-overflow",
+			wantURL:     "https://github.com/fork-owner/repo.git",
+			wantRef:     "lilac/text-overflow",
+			wantHeadRef: "lilac/text-overflow",
+		},
+		{
+			name:        "code-url without ref",
+			codeURL:     "https://github.com/owner/repo.git",
+			wantURL:     "https://github.com/owner/repo.git",
+			wantRef:     "",
+			wantHeadRef: "",
+		},
+		{
+			name:    "pr and code-url are mutually exclusive",
+			codeURL: "https://github.com/owner/repo.git",
+			prNum:   60,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveCodeSourceFromArgs(tt.codeURL, tt.codeRef, tt.prNum)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil result, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected resolved source, got nil")
+			}
+			if got.URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", got.URL, tt.wantURL)
+			}
+			if got.Ref != tt.wantRef {
+				t.Errorf("Ref = %q, want %q", got.Ref, tt.wantRef)
+			}
+			if got.HeadRef != tt.wantHeadRef {
+				t.Errorf("HeadRef = %q, want %q", got.HeadRef, tt.wantHeadRef)
+			}
+		})
+	}
+}
+
 func TestIsSensitiveKey(t *testing.T) {
 	tests := []struct {
 		key      string

--- a/coordinator_api/internal/handlers/eval_job.go
+++ b/coordinator_api/internal/handlers/eval_job.go
@@ -11,9 +11,27 @@ import (
 
 // BuildEvalJob constructs an eval job from a project and webhook event.
 // The eval job runs runnerlib eval to determine which CI jobs should be triggered.
+//
+// Code source vs CI source: the code under test (SourceURL/SourceRef) may live
+// on a fork for cross-repository PRs; the CI definitions (CISourceURL/
+// CISourceRef) must always come from a trusted location — the project's
+// configured DefaultCISource, or the upstream repository's base ref. Fork
+// content is NEVER used as a CI source: a malicious PR could otherwise ship
+// .reactorcide/jobs/*.yaml that would be executed by the eval job.
 func BuildEvalJob(project *models.Project, event *vcs.WebhookEvent) *models.Job {
 	sourceType := models.SourceTypeGit
-	sourceURL := event.Repository.CloneURL
+
+	// Code source URL: for fork PRs, points at the fork; otherwise upstream.
+	// Existing job YAMLs that do `git clone $REACTORCIDE_SOURCE_URL` keep
+	// working unchanged for fork PRs because SOURCE_URL now resolves to the
+	// repo where the branch actually lives.
+	upstreamURL := event.Repository.CloneURL
+	sourceURL := upstreamURL
+	isForkPR := false
+	if event.PullRequest != nil && event.PullRequest.HeadRepository != nil {
+		sourceURL = event.PullRequest.HeadRepository.CloneURL
+		isForkPR = true
+	}
 
 	// Determine source ref, branch, and job name based on event type
 	var sourceRef, branch, jobName string
@@ -22,7 +40,7 @@ func BuildEvalJob(project *models.Project, event *vcs.WebhookEvent) *models.Job 
 		"REACTORCIDE_PROVIDER":   string(event.Provider),
 		"REACTORCIDE_EVENT_TYPE": string(event.GenericEvent),
 		"REACTORCIDE_REPO":       event.Repository.FullName,
-		"REACTORCIDE_SOURCE_URL": event.Repository.CloneURL,
+		"REACTORCIDE_SOURCE_URL": sourceURL,
 	}
 
 	if event.PullRequest != nil {
@@ -37,6 +55,16 @@ func BuildEvalJob(project *models.Project, event *vcs.WebhookEvent) *models.Job 
 		envVars["REACTORCIDE_PR_REF"] = pr.HeadRef
 		envVars["REACTORCIDE_PR_BASE_REF"] = pr.BaseRef
 		envVars["REACTORCIDE_DIFF_BASE"] = pr.BaseSHA
+
+		// Explicit head/base URL pair lets job authors set up both remotes
+		// (e.g. for `git log base..head`) without overloading SOURCE_URL.
+		envVars["REACTORCIDE_HEAD_URL"] = sourceURL
+		envVars["REACTORCIDE_HEAD_REF"] = pr.HeadRef
+		envVars["REACTORCIDE_BASE_URL"] = upstreamURL
+		envVars["REACTORCIDE_BASE_REF"] = pr.BaseRef
+		if isForkPR {
+			envVars["REACTORCIDE_IS_FORK_PR"] = "true"
+		}
 	} else if event.Push != nil {
 		push := event.Push
 		sourceRef = push.After
@@ -64,13 +92,24 @@ func BuildEvalJob(project *models.Project, event *vcs.WebhookEvent) *models.Job 
 		envVars["REACTORCIDE_CI_SOURCE_URL"] = project.DefaultCISourceURL
 		envVars["REACTORCIDE_CI_SOURCE_REF"] = project.DefaultCISourceRef
 	} else {
-		// Same-repo mode: use the source repo for job definitions
+		// Same-repo mode: use the upstream repo for job definitions. For PR
+		// events, anchor at the base branch's SHA (trusted state of the
+		// target) rather than the PR head — otherwise a fork PR could ship
+		// malicious .reactorcide/jobs/*.yaml that the eval job would execute.
+		// For push events, the push has already passed the project's commit
+		// gates, so the pushed SHA is trusted.
 		st := models.SourceTypeGit
 		ciSourceType = &st
-		ciSourceURL = &sourceURL
-		ciSourceRef = &sourceRef
-		envVars["REACTORCIDE_CI_SOURCE_URL"] = sourceURL
-		envVars["REACTORCIDE_CI_SOURCE_REF"] = sourceRef
+		ciSourceURL = &upstreamURL
+		var ciRef string
+		if event.PullRequest != nil {
+			ciRef = event.PullRequest.BaseSHA
+		} else {
+			ciRef = sourceRef
+		}
+		ciSourceRef = &ciRef
+		envVars["REACTORCIDE_CI_SOURCE_URL"] = upstreamURL
+		envVars["REACTORCIDE_CI_SOURCE_REF"] = ciRef
 	}
 
 	// Determine job command

--- a/coordinator_api/internal/handlers/eval_job_test.go
+++ b/coordinator_api/internal/handlers/eval_job_test.go
@@ -91,6 +91,111 @@ func TestBuildEvalJob_PROpened(t *testing.T) {
 	assert.Equal(t, "main", job.JobEnvVars["REACTORCIDE_CI_SOURCE_REF"])
 }
 
+func TestBuildEvalJob_PRFromFork(t *testing.T) {
+	// Cross-repo PR: head branch lives on a fork, base lives on upstream.
+	// Code source (SourceURL) must be the fork; CI source must be upstream.
+	project := evalTestProject()
+	// Clear project's DefaultCISourceURL so we exercise the same-repo CI
+	// fallback path and verify it correctly anchors on the upstream + base SHA.
+	project.DefaultCISourceURL = ""
+	project.DefaultCISourceRef = ""
+
+	event := &vcs.WebhookEvent{
+		Provider:     vcs.GitHub,
+		EventType:    "pull_request",
+		GenericEvent: vcs.EventPullRequestOpened,
+		Repository: vcs.RepositoryInfo{
+			FullName: "upstream/repo",
+			CloneURL: "https://github.com/upstream/repo.git",
+		},
+		PullRequest: &vcs.PullRequestInfo{
+			Number:  60,
+			Action:  "opened",
+			HeadSHA: "forkheadsha",
+			HeadRef: "lilac/text-overflow",
+			BaseSHA: "upstreambaseSHA",
+			BaseRef: "main",
+			HeadRepository: &vcs.RepositoryInfo{
+				FullName: "fork-owner/repo",
+				CloneURL: "https://github.com/fork-owner/repo.git",
+			},
+		},
+	}
+
+	job := BuildEvalJob(project, event)
+
+	// Code source: must point at the FORK so `git clone` reaches the branch.
+	require.NotNil(t, job.SourceURL)
+	assert.Equal(t, "https://github.com/fork-owner/repo.git", *job.SourceURL)
+	require.NotNil(t, job.SourceRef)
+	assert.Equal(t, "forkheadsha", *job.SourceRef)
+
+	// CI source: must point at UPSTREAM at the BASE SHA — not the fork,
+	// not the head SHA. This is the security boundary: fork content must
+	// never be loaded as CI definitions.
+	require.NotNil(t, job.CISourceURL)
+	assert.Equal(t, "https://github.com/upstream/repo.git", *job.CISourceURL)
+	require.NotNil(t, job.CISourceRef)
+	assert.Equal(t, "upstreambaseSHA", *job.CISourceRef)
+
+	// Env vars: SOURCE_URL == HEAD_URL == fork. BASE_URL == upstream.
+	assert.Equal(t, "https://github.com/fork-owner/repo.git", job.JobEnvVars["REACTORCIDE_SOURCE_URL"])
+	assert.Equal(t, "https://github.com/fork-owner/repo.git", job.JobEnvVars["REACTORCIDE_HEAD_URL"])
+	assert.Equal(t, "lilac/text-overflow", job.JobEnvVars["REACTORCIDE_HEAD_REF"])
+	assert.Equal(t, "https://github.com/upstream/repo.git", job.JobEnvVars["REACTORCIDE_BASE_URL"])
+	assert.Equal(t, "main", job.JobEnvVars["REACTORCIDE_BASE_REF"])
+	assert.Equal(t, "true", job.JobEnvVars["REACTORCIDE_IS_FORK_PR"])
+	assert.Equal(t, "https://github.com/upstream/repo.git", job.JobEnvVars["REACTORCIDE_CI_SOURCE_URL"])
+	assert.Equal(t, "upstreambaseSHA", job.JobEnvVars["REACTORCIDE_CI_SOURCE_REF"])
+
+	// Back-compat env vars must still be set.
+	assert.Equal(t, "lilac/text-overflow", job.JobEnvVars["REACTORCIDE_PR_REF"])
+	assert.Equal(t, "main", job.JobEnvVars["REACTORCIDE_PR_BASE_REF"])
+}
+
+func TestBuildEvalJob_SameRepoPR_CISourceUsesBaseSHA(t *testing.T) {
+	// Security: even for same-repo PRs, if the project hasn't configured a
+	// trusted DefaultCISourceURL, CI definitions must come from the base
+	// branch's SHA — not the PR head — so an untrusted contributor cannot
+	// modify CI by pushing to their PR branch.
+	project := evalTestProject()
+	project.DefaultCISourceURL = ""
+	project.DefaultCISourceRef = ""
+
+	event := &vcs.WebhookEvent{
+		Provider:     vcs.GitHub,
+		EventType:    "pull_request",
+		GenericEvent: vcs.EventPullRequestOpened,
+		Repository: vcs.RepositoryInfo{
+			FullName: "org/repo",
+			CloneURL: "https://github.com/org/repo.git",
+		},
+		PullRequest: &vcs.PullRequestInfo{
+			Number:  7,
+			Action:  "opened",
+			HeadSHA: "untrustedHEADsha",
+			HeadRef: "contributor-branch",
+			BaseSHA: "trustedBASEsha",
+			BaseRef: "main",
+		},
+	}
+
+	job := BuildEvalJob(project, event)
+
+	// Code source: same-repo PR, so upstream URL with the head SHA.
+	require.NotNil(t, job.SourceURL)
+	assert.Equal(t, "https://github.com/org/repo.git", *job.SourceURL)
+	assert.Equal(t, "untrustedHEADsha", *job.SourceRef)
+
+	// CI source: BaseSHA, NOT HeadSHA. This is the security fix.
+	require.NotNil(t, job.CISourceRef)
+	assert.Equal(t, "trustedBASEsha", *job.CISourceRef)
+	assert.Equal(t, "https://github.com/org/repo.git", *job.CISourceURL)
+
+	// IS_FORK_PR must not be set for same-repo PRs.
+	assert.Nil(t, job.JobEnvVars["REACTORCIDE_IS_FORK_PR"])
+}
+
 func TestBuildEvalJob_PRUpdated(t *testing.T) {
 	project := evalTestProject()
 	event := &vcs.WebhookEvent{

--- a/coordinator_api/internal/vcs/github.go
+++ b/coordinator_api/internal/vcs/github.go
@@ -384,6 +384,21 @@ func (c *GitHubClient) parsePullRequestEvent(body []byte, event *WebhookEvent) e
 		AuthorEmail: "", // Not provided in webhook
 	}
 
+	// Cross-repo (fork) PR: the head branch lives on a different repository
+	// than the base. Capture the head repository so downstream code can clone
+	// from the fork to reach HeadRef.
+	headFullName := payload.PullRequest.Head.Repo.FullName
+	baseFullName := payload.PullRequest.Base.Repo.FullName
+	if headFullName != "" && baseFullName != "" && headFullName != baseFullName {
+		event.PullRequest.HeadRepository = &RepositoryInfo{
+			FullName:      payload.PullRequest.Head.Repo.FullName,
+			CloneURL:      payload.PullRequest.Head.Repo.CloneURL,
+			SSHURL:        payload.PullRequest.Head.Repo.SSHURL,
+			HTMLURL:       payload.PullRequest.Head.Repo.HTMLURL,
+			DefaultBranch: payload.PullRequest.Head.Repo.DefaultBranch,
+		}
+	}
+
 	return nil
 }
 

--- a/coordinator_api/internal/vcs/github_test.go
+++ b/coordinator_api/internal/vcs/github_test.go
@@ -68,6 +68,65 @@ func TestGitHubClient_ParseWebhook(t *testing.T) {
 				assert.False(t, event.PullRequest.Merged)
 				assert.Equal(t, "abc123", event.PullRequest.HeadSHA)
 				assert.Equal(t, "test/repo", event.Repository.FullName)
+				// Same-repo PR: HeadRepository must be nil.
+				assert.Nil(t, event.PullRequest.HeadRepository)
+			},
+		},
+		{
+			name:      "pull_request_from_fork",
+			eventType: "pull_request",
+			payload: `{
+				"action": "opened",
+				"number": 60,
+				"pull_request": {
+					"number": 60,
+					"title": "Fork PR",
+					"body": "From a fork",
+					"state": "open",
+					"merged": false,
+					"html_url": "https://github.com/upstream/repo/pull/60",
+					"head": {
+						"ref": "lilac/text-overflow",
+						"sha": "c9fbf58330",
+						"repo": {
+							"full_name": "fork-owner/repo",
+							"clone_url": "https://github.com/fork-owner/repo.git",
+							"ssh_url": "git@github.com:fork-owner/repo.git",
+							"html_url": "https://github.com/fork-owner/repo",
+							"default_branch": "main"
+						}
+					},
+					"base": {
+						"ref": "main",
+						"sha": "basesha789",
+						"repo": {
+							"full_name": "upstream/repo",
+							"clone_url": "https://github.com/upstream/repo.git",
+							"ssh_url": "git@github.com:upstream/repo.git",
+							"html_url": "https://github.com/upstream/repo",
+							"default_branch": "main"
+						}
+					},
+					"user": {
+						"login": "forkowner"
+					}
+				},
+				"repository": {
+					"full_name": "upstream/repo",
+					"clone_url": "https://github.com/upstream/repo.git",
+					"ssh_url": "git@github.com:upstream/repo.git",
+					"html_url": "https://github.com/upstream/repo",
+					"default_branch": "main"
+				}
+			}`,
+			wantErr: false,
+			checkResult: func(t *testing.T, event *WebhookEvent) {
+				assert.Equal(t, "upstream/repo", event.Repository.FullName)
+				assert.Equal(t, "https://github.com/upstream/repo.git", event.Repository.CloneURL)
+				assert.Equal(t, "lilac/text-overflow", event.PullRequest.HeadRef)
+				require.NotNil(t, event.PullRequest.HeadRepository)
+				assert.Equal(t, "fork-owner/repo", event.PullRequest.HeadRepository.FullName)
+				assert.Equal(t, "https://github.com/fork-owner/repo.git", event.PullRequest.HeadRepository.CloneURL)
 			},
 		},
 		{

--- a/coordinator_api/internal/vcs/interface.go
+++ b/coordinator_api/internal/vcs/interface.go
@@ -48,6 +48,13 @@ type PullRequestInfo struct {
 	HTMLURL     string
 	AuthorLogin string
 	AuthorEmail string
+
+	// HeadRepository is set only for cross-repository PRs (forks).
+	// When nil, the PR's head branch lives on the same repository as Repository
+	// in the enclosing WebhookEvent. When non-nil, this is the fork where the
+	// branch actually lives — clone from HeadRepository.CloneURL to reach
+	// HeadRef.
+	HeadRepository *RepositoryInfo
 }
 
 // PushInfo contains push event information

--- a/examples/jobs/pr-from-fork.yaml
+++ b/examples/jobs/pr-from-fork.yaml
@@ -1,0 +1,49 @@
+name: pr-from-fork-example
+description: |
+  Example raw-command job that handles both fork PRs and same-repo PRs
+  correctly. Clones from the head repo (the fork for cross-repo PRs) and
+  optionally adds the upstream as a second remote so diff-base operations
+  work even when the fork doesn't have the upstream's tip.
+
+  Run locally against a fork PR:
+    reactorcide run-local --pr 60 examples/jobs/pr-from-fork.yaml
+  Or with explicit URL + ref:
+    reactorcide run-local \
+      --code-url https://github.com/fork-owner/repo.git \
+      --code-ref some-feature-branch \
+      examples/jobs/pr-from-fork.yaml
+
+job:
+  image: alpine/git:latest
+  raw_command: true
+  command: |
+    set -e
+    # HEAD_URL points at the fork for cross-repo PRs; falls back to
+    # SOURCE_URL for back-compat with older worker versions. Same for HEAD_REF
+    # vs PR_REF and BASE_URL/BASE_REF.
+    HEAD_URL="${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}"
+    HEAD_REF="${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}"
+    BASE_URL="${REACTORCIDE_BASE_URL}"
+    BASE_REF="${REACTORCIDE_BASE_REF:-$REACTORCIDE_PR_BASE_REF}"
+
+    echo "Cloning code source: ${HEAD_URL} @ ${HEAD_REF}"
+    git clone --branch "${HEAD_REF}" "${HEAD_URL}" /job/src
+    cd /job/src
+
+    # Add upstream as a second remote for diff-base ops (only if it differs).
+    if [ -n "${BASE_URL}" ] && [ "${BASE_URL}" != "${HEAD_URL}" ]; then
+      echo "Adding upstream remote: ${BASE_URL}"
+      git remote add upstream "${BASE_URL}"
+      git fetch upstream "${BASE_REF}"
+      echo "Commits added by this PR:"
+      git log "upstream/${BASE_REF}..HEAD" --oneline
+    elif [ -n "${REACTORCIDE_DIFF_BASE}" ]; then
+      echo "Same-repo PR — diffing against base SHA ${REACTORCIDE_DIFF_BASE}"
+      git log "${REACTORCIDE_DIFF_BASE}..HEAD" --oneline
+    fi
+
+    if [ "${REACTORCIDE_IS_FORK_PR:-}" = "true" ]; then
+      echo "This is a fork PR."
+    fi
+  timeout: 300
+  priority: 5

--- a/runnerlib/src/cli.py
+++ b/runnerlib/src/cli.py
@@ -756,6 +756,11 @@ def eval_cmd(
     source_ref: str = typer.Option("", envvar="REACTORCIDE_SHA", help="Source git reference (SHA)"),
     ci_source_url: str = typer.Option("", envvar="REACTORCIDE_CI_SOURCE_URL", help="CI source repository URL"),
     ci_source_ref: str = typer.Option("", envvar="REACTORCIDE_CI_SOURCE_REF", help="CI source git reference"),
+    head_url: str = typer.Option("", envvar="REACTORCIDE_HEAD_URL", help="PR head repository URL (fork URL for cross-repo PRs)"),
+    head_ref: str = typer.Option("", envvar="REACTORCIDE_HEAD_REF", help="PR head branch name"),
+    base_url: str = typer.Option("", envvar="REACTORCIDE_BASE_URL", help="PR base/upstream repository URL"),
+    base_ref: str = typer.Option("", envvar="REACTORCIDE_BASE_REF", help="PR base branch name"),
+    is_fork_pr: str = typer.Option("", envvar="REACTORCIDE_IS_FORK_PR", help="Set to 'true' when PR is cross-repository"),
     triggers_file: str = typer.Option("/job/triggers.json", help="Path to write triggers output"),
 ):
     """Evaluate job definitions against an event and generate triggers.
@@ -843,6 +848,11 @@ def eval_cmd(
         ci_source_ref=ci_source_ref,
         pr_base_ref=pr_base_ref,
         pr_number=pr_number,
+        head_url=head_url,
+        head_ref=head_ref,
+        base_url=base_url,
+        base_ref=base_ref,
+        is_fork_pr=is_fork_pr,
     )
 
     # Generate triggers
@@ -898,6 +908,11 @@ def trigger_cmd(
         "REACTORCIDE_DIFF_BASE",
         "REACTORCIDE_CI_SOURCE_URL",
         "REACTORCIDE_CI_SOURCE_REF",
+        "REACTORCIDE_HEAD_URL",
+        "REACTORCIDE_HEAD_REF",
+        "REACTORCIDE_BASE_URL",
+        "REACTORCIDE_BASE_REF",
+        "REACTORCIDE_IS_FORK_PR",
     ]
 
     triggers: List[JobTrigger] = []

--- a/runnerlib/src/eval.py
+++ b/runnerlib/src/eval.py
@@ -115,12 +115,18 @@ class EventContext:
     Attributes:
         event_type: The generic event type (e.g. "push", "pull_request_opened").
         branch: The branch name.
-        source_url: URL of the source code repository.
+        source_url: URL of the source code repository (fork URL for cross-repo PRs).
         source_ref: Git ref (SHA) of the source code.
-        ci_source_url: URL of the CI source repository.
+        ci_source_url: URL of the CI source repository (always trusted upstream).
         ci_source_ref: Git ref of the CI source.
         pr_base_ref: Base branch for pull requests.
         pr_number: Pull request number.
+        head_url: Explicit head repo URL for PRs (== source_url; convenience).
+        head_ref: PR head branch name (== pr ref for PRs).
+        base_url: Upstream/base repo URL for PRs — useful when jobs need a
+            second remote (e.g. for `git log base..head` operations).
+        base_ref: Target branch for PRs (== pr_base_ref; convenience).
+        is_fork_pr: "true" when the PR head is on a different repo than base.
     """
     event_type: str = ""
     branch: str = ""
@@ -130,6 +136,11 @@ class EventContext:
     ci_source_ref: str = ""
     pr_base_ref: str = ""
     pr_number: str = ""
+    head_url: str = ""
+    head_ref: str = ""
+    base_url: str = ""
+    base_ref: str = ""
+    is_fork_pr: str = ""
 
 
 def _parse_triggers_config(data: Any) -> TriggersConfig:
@@ -446,6 +457,16 @@ def generate_triggers(
             env["REACTORCIDE_CI_SOURCE_URL"] = event_context.ci_source_url
         if event_context.ci_source_ref:
             env["REACTORCIDE_CI_SOURCE_REF"] = event_context.ci_source_ref
+        if event_context.head_url:
+            env["REACTORCIDE_HEAD_URL"] = event_context.head_url
+        if event_context.head_ref:
+            env["REACTORCIDE_HEAD_REF"] = event_context.head_ref
+        if event_context.base_url:
+            env["REACTORCIDE_BASE_URL"] = event_context.base_url
+        if event_context.base_ref:
+            env["REACTORCIDE_BASE_REF"] = event_context.base_ref
+        if event_context.is_fork_pr:
+            env["REACTORCIDE_IS_FORK_PR"] = event_context.is_fork_pr
 
         # By default, wrap the command with "runnerlib run --job-command" so that
         # runnerlib handles source checkout, CI source checkout, secret resolution,

--- a/runnerlib/src/source_prep.py
+++ b/runnerlib/src/source_prep.py
@@ -9,7 +9,12 @@ from src.logging import log_stdout, log_stderr, logger
 from src.config import RunnerConfig, get_config
 
 
-def _checkout_with_fetch_fallback(repo: Repo, source_ref: str) -> None:
+def _checkout_with_fetch_fallback(
+    repo: Repo,
+    source_ref: str,
+    base_url: Optional[str] = None,
+    base_ref: Optional[str] = None,
+) -> None:
     """Checkout a git ref, fetching PR refs as fallback if needed.
 
     For PR events, the source_ref SHA may not exist in the default clone
@@ -17,63 +22,98 @@ def _checkout_with_fetch_fallback(repo: Repo, source_ref: str) -> None:
     refs/merge-requests/<N>/head (GitLab). This function tries a direct
     checkout first, then falls back to fetching the specific PR ref.
 
+    When base_url is provided and differs from origin's URL (the cross-repo
+    PR case — origin is the fork, base is upstream), an "upstream" remote
+    is added and base_ref is fetched. This makes operations like
+    `git log upstream/<base_ref>..HEAD` work for jobs that need to inspect
+    the diff against the PR's target branch.
+
     Args:
         repo: GitPython Repo instance (already cloned)
         source_ref: Git reference to checkout (branch, tag, or commit SHA)
+        base_url: Optional second remote URL (the PR's base/upstream repo).
+            When set and != origin, added as remote "upstream".
+        base_ref: Optional base branch to fetch from the upstream remote.
 
     Raises:
         GitCommandError: If all checkout attempts fail
     """
     # Try direct checkout first — works for branches, tags, and commits on fetched branches
+    checked_out = False
     try:
         repo.git.checkout(source_ref)
-        return
+        checked_out = True
     except GitCommandError:
         logger.debug("Direct checkout failed, trying fetch fallbacks", fields={"ref": source_ref})
 
-    # Try fetching the specific SHA (works if server has uploadpack.allowReachableSHA1InWant)
-    try:
-        repo.git.fetch("origin", source_ref)
-        repo.git.checkout(source_ref)
-        log_stdout(f"Fetched and checked out ref: {source_ref}")
-        return
-    except GitCommandError:
-        logger.debug("Fetch by SHA failed", fields={"ref": source_ref})
+    if not checked_out:
+        # Try fetching the specific SHA (works if server has uploadpack.allowReachableSHA1InWant)
+        try:
+            repo.git.fetch("origin", source_ref)
+            repo.git.checkout(source_ref)
+            log_stdout(f"Fetched and checked out ref: {source_ref}")
+            checked_out = True
+        except GitCommandError:
+            logger.debug("Fetch by SHA failed", fields={"ref": source_ref})
 
-    # Try PR-specific refs using REACTORCIDE_PR_NUMBER
-    pr_number = os.getenv("REACTORCIDE_PR_NUMBER", "")
-    if pr_number:
-        # GitHub: refs/pull/<N>/head
-        pr_refs = [
-            f"refs/pull/{pr_number}/head",
-            f"refs/merge-requests/{pr_number}/head",  # GitLab
-        ]
-        for pr_ref in pr_refs:
+    if not checked_out:
+        # Try PR-specific refs using REACTORCIDE_PR_NUMBER
+        pr_number = os.getenv("REACTORCIDE_PR_NUMBER", "")
+        if pr_number:
+            # GitHub: refs/pull/<N>/head
+            pr_refs = [
+                f"refs/pull/{pr_number}/head",
+                f"refs/merge-requests/{pr_number}/head",  # GitLab
+            ]
+            for pr_ref in pr_refs:
+                try:
+                    log_stdout(f"Fetching PR ref: {pr_ref}")
+                    repo.git.fetch("origin", f"{pr_ref}:refs/remotes/origin/pr-head")
+                    repo.git.checkout(source_ref)
+                    log_stdout(f"Checked out PR ref: {source_ref}")
+                    checked_out = True
+                    break
+                except GitCommandError:
+                    logger.debug("PR ref fetch failed", fields={"pr_ref": pr_ref})
+
+    if not checked_out:
+        # Last resort: fetch all remote refs (handles any branch the SHA might be on)
+        try:
+            log_stdout("Fetching all remote refs...")
+            repo.git.fetch("origin", "+refs/heads/*:refs/remotes/origin/*")
+            repo.git.checkout(source_ref)
+            log_stdout(f"Checked out ref after full fetch: {source_ref}")
+            checked_out = True
+        except GitCommandError:
+            pass
+
+    if not checked_out:
+        # Nothing worked — raise with a clear message
+        raise GitCommandError(
+            f"git checkout {source_ref}",
+            128,
+            stderr=f"Could not checkout ref '{source_ref}' after all fetch attempts",
+        )
+
+    # After checkout: optionally add upstream remote for cross-repo PR diff ops.
+    if base_url:
+        try:
+            origin_url = next(iter(repo.remotes.origin.urls), None)
+        except Exception:
+            origin_url = None
+        if origin_url and origin_url != base_url:
             try:
-                log_stdout(f"Fetching PR ref: {pr_ref}")
-                repo.git.fetch("origin", f"{pr_ref}:refs/remotes/origin/pr-head")
-                repo.git.checkout(source_ref)
-                log_stdout(f"Checked out PR ref: {source_ref}")
-                return
-            except GitCommandError:
-                logger.debug("PR ref fetch failed", fields={"pr_ref": pr_ref})
-
-    # Last resort: fetch all remote refs (handles any branch the SHA might be on)
-    try:
-        log_stdout("Fetching all remote refs...")
-        repo.git.fetch("origin", "+refs/heads/*:refs/remotes/origin/*")
-        repo.git.checkout(source_ref)
-        log_stdout(f"Checked out ref after full fetch: {source_ref}")
-        return
-    except GitCommandError:
-        pass
-
-    # Nothing worked — raise with a clear message
-    raise GitCommandError(
-        f"git checkout {source_ref}",
-        128,
-        stderr=f"Could not checkout ref '{source_ref}' after all fetch attempts",
-    )
+                if "upstream" in [r.name for r in repo.remotes]:
+                    logger.debug("upstream remote already present, skipping add")
+                else:
+                    repo.create_remote("upstream", base_url)
+                    log_stdout(f"Added upstream remote: {base_url}")
+                if base_ref:
+                    repo.git.fetch("upstream", base_ref)
+                    log_stdout(f"Fetched upstream/{base_ref}")
+            except GitCommandError as e:
+                # Non-fatal: jobs that don't need diff-base ops still succeed.
+                log_stderr(f"Warning: could not set up upstream remote ({base_url}): {e}")
 
 
 def is_in_container_mode() -> bool:
@@ -221,7 +261,12 @@ def checkout_git_repo(
         if git_ref:
             logger.debug("Checking out git ref", fields={"ref": git_ref})
             log_stdout(f"Checking out ref: {git_ref}")
-            _checkout_with_fetch_fallback(repo, git_ref)
+            _checkout_with_fetch_fallback(
+                repo,
+                git_ref,
+                base_url=os.getenv("REACTORCIDE_BASE_URL") or None,
+                base_ref=os.getenv("REACTORCIDE_BASE_REF") or None,
+            )
 
         logger.info("Repository cloned successfully", fields={"path": str(src_path)})
         log_stdout(f"Repository checked out to: {src_path}")
@@ -400,7 +445,12 @@ def _prepare_git_source(source_url: str, source_ref: Optional[str], target_path:
         if source_ref:
             logger.debug("Checking out git ref", fields={"ref": source_ref})
             log_stdout(f"Checking out ref: {source_ref}")
-            _checkout_with_fetch_fallback(repo, source_ref)
+            _checkout_with_fetch_fallback(
+                repo,
+                source_ref,
+                base_url=os.getenv("REACTORCIDE_BASE_URL") or None,
+                base_ref=os.getenv("REACTORCIDE_BASE_REF") or None,
+            )
 
         logger.info("Git source prepared successfully", fields={"path": str(target_path)})
         log_stdout(f"Repository checked out to: {target_path}")

--- a/runnerlib/tests/test_eval.py
+++ b/runnerlib/tests/test_eval.py
@@ -687,6 +687,62 @@ class TestGenerateTriggers:
         assert t.ci_source_url == "https://github.com/org/ci.git"
         assert t.ci_source_ref == "def456"
 
+    def test_trigger_propagates_fork_pr_env(self):
+        """Fork PR context: head/base URLs + IS_FORK_PR must reach trigger env."""
+        defs = [
+            JobDefinition(
+                name="test",
+                job=JobConfig(image="alpine:latest", command="make test"),
+            ),
+        ]
+        ctx = EventContext(
+            event_type="pull_request_opened",
+            branch="main",
+            source_url="https://github.com/fork-owner/repo.git",
+            source_ref="forkheadsha",
+            ci_source_url="https://github.com/upstream/repo.git",
+            ci_source_ref="upstreambaseSHA",
+            pr_base_ref="main",
+            pr_number="60",
+            head_url="https://github.com/fork-owner/repo.git",
+            head_ref="lilac/text-overflow",
+            base_url="https://github.com/upstream/repo.git",
+            base_ref="main",
+            is_fork_pr="true",
+        )
+
+        triggers = generate_triggers(defs, ctx)
+
+        assert len(triggers) == 1
+        t = triggers[0]
+        # SOURCE_URL points at the fork (where the branch lives).
+        assert t.env["REACTORCIDE_SOURCE_URL"] == "https://github.com/fork-owner/repo.git"
+        # Explicit head/base pair lets jobs set up two remotes.
+        assert t.env["REACTORCIDE_HEAD_URL"] == "https://github.com/fork-owner/repo.git"
+        assert t.env["REACTORCIDE_HEAD_REF"] == "lilac/text-overflow"
+        assert t.env["REACTORCIDE_BASE_URL"] == "https://github.com/upstream/repo.git"
+        assert t.env["REACTORCIDE_BASE_REF"] == "main"
+        assert t.env["REACTORCIDE_IS_FORK_PR"] == "true"
+        # CI source comes from upstream — never the fork.
+        assert t.env["REACTORCIDE_CI_SOURCE_URL"] == "https://github.com/upstream/repo.git"
+
+    def test_trigger_omits_fork_env_when_unset(self):
+        """Non-fork contexts should not leak HEAD/BASE/IS_FORK_PR vars."""
+        defs = [
+            JobDefinition(
+                name="test",
+                job=JobConfig(image="alpine:latest", command="make test"),
+            ),
+        ]
+        ctx = EventContext(event_type="push", branch="main", source_url="https://github.com/org/repo.git")
+
+        triggers = generate_triggers(defs, ctx)
+
+        t = triggers[0]
+        assert "REACTORCIDE_HEAD_URL" not in t.env
+        assert "REACTORCIDE_BASE_URL" not in t.env
+        assert "REACTORCIDE_IS_FORK_PR" not in t.env
+
     def test_trigger_with_priority_and_timeout(self):
         """Test that priority and timeout are passed through."""
         defs = [

--- a/runnerlib/tests/test_source_preparation.py
+++ b/runnerlib/tests/test_source_preparation.py
@@ -368,3 +368,70 @@ class TestSourcePreparation:
         assert result is not None
         assert (result / "pr_change.txt").exists()
         assert (result / "pr_change.txt").read_text() == "PR changes"
+
+    def test_checkout_with_fetch_fallback_adds_upstream_remote(self):
+        """When base_url is provided and differs from origin, upstream remote
+        is added and base_ref is fetched. This is the fork-PR scenario where
+        the clone is the fork and base operations need the upstream remote.
+        """
+        # Simulate: upstream has 'main', fork has 'main' + 'feature-branch'
+        upstream_bare = Path(self.temp_dir) / "upstream.git"
+        Repo.init(upstream_bare, bare=True)
+        fork_bare = Path(self.temp_dir) / "fork.git"
+        Repo.init(fork_bare, bare=True)
+
+        # Seed both with a main commit
+        seed_dir = Path(self.temp_dir) / "seed"
+        seed = _init_repo_with_main(seed_dir)
+        (seed_dir / "main.txt").write_text("base")
+        seed.index.add(["main.txt"])
+        seed.index.commit("base")
+        seed.create_remote("upstream", str(upstream_bare))
+        seed.create_remote("fork", str(fork_bare))
+        seed.remotes.upstream.push("HEAD:refs/heads/main")
+        seed.remotes.fork.push("HEAD:refs/heads/main")
+
+        # Add a fork-only feature branch on the fork
+        seed.git.checkout("-b", "feature")
+        (seed_dir / "feature.txt").write_text("fork work")
+        seed.index.add(["feature.txt"])
+        seed.index.commit("feature")
+        seed.remotes.fork.push("HEAD:refs/heads/feature")
+
+        # Clone the fork (origin = fork)
+        clone_dir = Path(self.temp_dir) / "clone"
+        cloned = Repo.clone_from(str(fork_bare), clone_dir)
+
+        # Checkout the feature branch with upstream as base.
+        _checkout_with_fetch_fallback(
+            cloned,
+            "feature",
+            base_url=str(upstream_bare),
+            base_ref="main",
+        )
+
+        # The 'upstream' remote should now exist, and upstream/main should be
+        # fetched so `git log upstream/main..HEAD` works.
+        remote_names = [r.name for r in cloned.remotes]
+        assert "upstream" in remote_names
+        assert "upstream/main" in [str(ref) for ref in cloned.refs]
+
+    def test_checkout_with_fetch_fallback_skips_upstream_when_same_url(self):
+        """When base_url matches origin URL (same-repo PR), no upstream remote."""
+        bare = Path(self.temp_dir) / "bare.git"
+        Repo.init(bare, bare=True)
+        seed_dir = Path(self.temp_dir) / "seed"
+        seed = _init_repo_with_main(seed_dir)
+        (seed_dir / "f.txt").write_text("x")
+        seed.index.add(["f.txt"])
+        seed.index.commit("init")
+        seed.create_remote("origin", str(bare))
+        seed.remotes.origin.push("HEAD:refs/heads/main")
+
+        clone_dir = Path(self.temp_dir) / "clone"
+        cloned = Repo.clone_from(str(bare), clone_dir)
+        _checkout_with_fetch_fallback(cloned, "main", base_url=str(bare), base_ref="main")
+
+        # No upstream remote added when base_url == origin url.
+        remote_names = [r.name for r in cloned.remotes]
+        assert "upstream" not in remote_names


### PR DESCRIPTION
We basically didn't handle this case at all, just branches on the same repo, which isn't great for open source fork PRs