### PR TITLE
fix: make comments a little more intuitive on PRs so jobs update when things happen that are the same commit

### DIFF
--- a/coordinator_api/internal/vcs/pr_comments.go
+++ b/coordinator_api/internal/vcs/pr_comments.go
@@ -88,8 +88,14 @@ func (u *JobStatusUpdater) postPerJobComment(ctx context.Context, client Client,
 
 // renderRollingCommentBody produces the markdown table summarizing every
 // job registered against (repo, PR, commit). Rows are rendered in job
-// creation order so the eval job shows first.
+// creation order so the eval job shows first. When the same job name has
+// been run multiple times (e.g. a webhook retry), only the most recent run
+// is shown — older runs would otherwise mislead readers into thinking a
+// long-since-fixed failure is current. Jobs are assumed to arrive in
+// ascending CreatedAt order (that's the contract of ListJobsForPRCommit).
 func (u *JobStatusUpdater) renderRollingCommentBody(jobs []models.Job, commitSHA, marker string) string {
+	deduped := dedupeJobsByName(jobs)
+
 	var b strings.Builder
 	shortSHA := commitSHA
 	if len(shortSHA) > 7 {
@@ -100,8 +106,8 @@ func (u *JobStatusUpdater) renderRollingCommentBody(jobs []models.Job, commitSHA
 	b.WriteString("| Job | Status | Duration | Link |\n")
 	b.WriteString("|-----|--------|----------|------|\n")
 
-	for i := range jobs {
-		job := &jobs[i]
+	for i := range deduped {
+		job := &deduped[i]
 		statusEmoji, statusText := renderStatus(job)
 		duration := renderDuration(job)
 		link := u.getJobURL(job.JobID)
@@ -120,6 +126,41 @@ func (u *JobStatusUpdater) renderRollingCommentBody(jobs []models.Job, commitSHA
 
 	fmt.Fprintf(&b, "\n<sub>Updated %s · %s</sub>\n", time.Now().UTC().Format(time.RFC3339), marker)
 	return b.String()
+}
+
+// dedupeJobsByName keeps only the most-recent job per Name from an ASC-by-
+// CreatedAt input. The returned slice preserves the original relative order
+// of kept jobs (so an eval registered first still renders first; a retried
+// child slots into its first appearance position with the newer job's
+// content). Jobs with an empty Name fall back to JobID as the dedup key so
+// they're never collapsed with one another.
+func dedupeJobsByName(jobs []models.Job) []models.Job {
+	if len(jobs) <= 1 {
+		return jobs
+	}
+	// keyOf collapses retries of the same job; pulling it out keeps the
+	// fallback rule (no-name → JobID) in one place.
+	keyOf := func(j *models.Job) string {
+		if j.Name != "" {
+			return j.Name
+		}
+		return j.JobID
+	}
+	latestIdx := make(map[string]int, len(jobs))
+	for i := range jobs {
+		latestIdx[keyOf(&jobs[i])] = i
+	}
+	keep := make(map[int]bool, len(latestIdx))
+	for _, idx := range latestIdx {
+		keep[idx] = true
+	}
+	out := make([]models.Job, 0, len(latestIdx))
+	for i := range jobs {
+		if keep[i] {
+			out = append(out, jobs[i])
+		}
+	}
+	return out
 }
 
 // renderPerJobCommentBody produces the body for a post-merge single-job

--- a/coordinator_api/internal/vcs/pr_comments_test.go
+++ b/coordinator_api/internal/vcs/pr_comments_test.go
@@ -1,0 +1,99 @@
+package vcs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/catalystcommunity/reactorcide/coordinator_api/internal/store/models"
+)
+
+func TestDedupeJobsByName(t *testing.T) {
+	// Helper to build a job with a name and a created-at offset (seconds).
+	mk := func(id, name string, offsetSec int, status string) models.Job {
+		return models.Job{
+			JobID:     id,
+			Name:      name,
+			Status:    status,
+			CreatedAt: time.Unix(int64(offsetSec), 0),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		in      []models.Job
+		wantIDs []string
+	}{
+		{
+			name:    "empty input",
+			in:      nil,
+			wantIDs: nil,
+		},
+		{
+			name:    "single job passes through",
+			in:      []models.Job{mk("a", "eval", 0, "completed")},
+			wantIDs: []string{"a"},
+		},
+		{
+			name: "no duplicates: all preserved in order",
+			in: []models.Job{
+				mk("a", "eval", 0, "completed"),
+				mk("b", "test-go", 1, "completed"),
+				mk("c", "test-py", 2, "completed"),
+			},
+			wantIDs: []string{"a", "b", "c"},
+		},
+		{
+			name: "retry of same name: keep latest, position of first occurrence is replaced",
+			in: []models.Job{
+				mk("old-eval", "eval", 0, "completed"),
+				mk("old-cc", "conventional-commits", 1, "failed"),
+				mk("new-eval", "eval", 10, "completed"),
+				mk("new-cc", "conventional-commits", 11, "completed"),
+				mk("test-go", "test-go", 12, "completed"),
+			},
+			// Expected order: the newer eval and conventional-commits are the
+			// kept ones (later CreatedAt), so they appear in their positions
+			// in the original ASC stream — slots 2 and 3 — followed by test-go.
+			// The older runs are dropped entirely.
+			wantIDs: []string{"new-eval", "new-cc", "test-go"},
+		},
+		{
+			name: "jobs with empty name dedupe by JobID (never collapsed together)",
+			in: []models.Job{
+				mk("a", "", 0, "completed"),
+				mk("b", "", 1, "completed"),
+			},
+			wantIDs: []string{"a", "b"},
+		},
+		{
+			name: "different-but-similar names (e.g. eval opened vs updated) stay separate",
+			in: []models.Job{
+				mk("e1", "eval: PR #60 opened on org/repo", 0, "completed"),
+				mk("e2", "eval: PR #60 updated on org/repo", 1, "completed"),
+			},
+			wantIDs: []string{"e1", "e2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dedupeJobsByName(tt.in)
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("dedupeJobsByName: got %d jobs, want %d (got IDs: %v)", len(got), len(tt.wantIDs), jobIDs(got))
+			}
+			for i, want := range tt.wantIDs {
+				if got[i].JobID != want {
+					t.Errorf("position %d: got JobID %q, want %q (full order: %v)", i, got[i].JobID, want, jobIDs(got))
+				}
+			}
+		})
+	}
+}
+
+func jobIDs(jobs []models.Job) []string {
+	out := make([]string, len(jobs))
+	for i, j := range jobs {
+		out[i] = j.JobID
+	}
+	return out
+}


### PR DESCRIPTION
What it says on the tin