### PR TITLE
fix: consistency in uid for run-local vs api options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,34 @@ Run-local supports cloning an arbitrary code source instead of bind-mounting you
 
 Both flags clone into a tempdir, mount it at `/job/src`, and set the same `REACTORCIDE_*` env vars the worker would set for a fork PR — so jobs behave identically locally and remotely. When neither flag is set, run-local bind-mounts `--job-dir` (your local working copy) as before.
 
+#### Matching the worker's runner uid (sudo / HOME parity)
+
+By default `run-local` runs the job container as the **host uid** — the right choice when the job writes back into your bind-mounted working copy (compilers emitting into the tree, codegen, `helm dependency update`, anything you then `git diff`). The worker, however, runs jobs as the image's runner uid **1001** (`runner`, HOME `/home/runner`, with the image's `NOPASSWD: apt-get` sudoers entry). So a job doing `sudo apt-get install …` passes on a worker but fails under run-local as the host uid.
+
+When you need that parity, opt in:
+
+```bash
+# Run as the image's runner uid 1001:1001, like the worker
+./coordinator_api/reactorcide run-local --as-runner .reactorcide/jobs/test-postgres.yaml
+
+# Or pin an explicit uid[:gid]
+./coordinator_api/reactorcide run-local --user 1001:1001 ./jobs/my-job.yaml
+```
+
+A job can also declare this once in its YAML so every flag-less `run-local` is consistent. The `run_local` block is **run-local-only — the worker ignores it entirely**:
+
+```yaml
+run_local:
+  as_runner: true      # run as 1001:1001 locally; or:
+  user: runner         # symbolic; also accepts "host" or "1001:1001"
+```
+
+`--user` / `run_local.user` accept a numeric `uid[:gid]` or the symbolic names `runner` (the image runner uid 1001) and `host` (the invoking user).
+
+Precedence (highest first): `--user` → `--as-runner` → `run_local.user` → `run_local.as_runner` → host uid (default). In parity mode run-local uses the image's real `/etc/passwd`/sudoers and lets HOME resolve from the image, matching the worker. **HOME is `/home/runner` and writable in both modes** — parity mode gets it from the image; the host-uid default mounts a fresh run-as-uid-owned scratch dir there — so `~`-reading tools (git, go, docker config) behave the same locally and remotely without `export HOME=…` boilerplate.
+
+**Caveat (by design):** in parity mode the bind-mounted `--job-dir` at `/job/src` is still host-owned, so a parity job can't *write into the source tree*. run-local deliberately has no plumbing to chown your working copy to the parity uid — a job that needs a writable checkout as the runner uid should use `--code-url`/`--pr` (cloned into a writable tempdir), or do its own cloning/ownership inside the job.
+
 ## Project Status
 
 The system is actively being developed with the core runnerlib functionality complete and the coordinator API providing job management capabilities. Join the [Catalyst Community Discord](https://discord.gg/sfNb9xRjPn) to discuss and contribute.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,6 +58,8 @@ This separation enables flexibility in deployment models: from running jobs loca
 
 **Unified run-local / worker model.** Run-local is the canonical execution path: a job declares what code it needs, and the executor provides it. Locally that means either bind-mounting your working copy (default) or cloning the requested source. Remotely, the worker performs the same bootstrap before invoking the job. The same `REACTORCIDE_HEAD_URL` / `BASE_URL` env vars are populated in both modes so job scripts behave identically.
 
+One deliberate divergence: **container uid**. The worker runs jobs as the image's runner uid (`1001`), while run-local defaults to the **host uid** — because it bind-mounts the operator's working copy, and running as that user lets jobs write back into the tree without a chown dance. The cost is that uid-sensitive behavior (the image's `NOPASSWD: apt-get` sudoers entry, file ownership) differs from the worker. Jobs that need worker parity opt in per-invocation (`run-local --as-runner` / `--user <uid:gid>`) or declare it once in a `run_local` block in the job YAML — a run-local-only block the worker ignores. In parity mode run-local uses the image's real `/etc/passwd`/sudoers instead of synthesizing them. `HOME` is a writable `/home/runner` in both modes (image-provided under parity, a run-as-uid-owned scratch mount under the host-uid default), so `~`-reading tools behave identically. run-local does **not** chown the bind-mounted working copy to a foreign uid — a parity job that needs a writable checkout clones one (`--code-url`/`--pr`) or handles ownership itself. See AGENTS.md for the full contract.
+
 This enables secure execution of CI/CD jobs against untrusted code contributions.
 
 ### 2. Environment Isolation First

--- a/coordinator_api/cmd/run_local.go
+++ b/coordinator_api/cmd/run_local.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/catalystcommunity/reactorcide/coordinator_api/internal/secrets"
 	"github.com/catalystcommunity/reactorcide/coordinator_api/internal/worker"
@@ -63,6 +64,101 @@ func hostRunAsUser() (uid, gid int) {
 	return uid, gid
 }
 
+// parseUserGroup parses a user spec into numeric ids. It accepts a numeric
+// "uid[:gid]" (gid defaults to the uid when omitted), or the symbolic names
+// "runner" (the image's conventional runner uid, 1001:1001) and "host" (the
+// invoking host user). Symbolic names let a job YAML say `run_local: { user:
+// runner }` without hard-coding 1001.
+func parseUserGroup(s string) (uid, gid int, err error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "runner":
+		return runnerUID, runnerGID, nil
+	case "host":
+		uid, gid = hostRunAsUser()
+		return uid, gid, nil
+	}
+	parts := strings.SplitN(strings.TrimSpace(s), ":", 2)
+	uid, err = strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid user %q: uid must be an integer", s)
+	}
+	gid = uid
+	if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+		gid, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid user %q: gid must be an integer", s)
+		}
+	}
+	return uid, gid, nil
+}
+
+// resolveRunAsUser determines the uid/gid the job container runs as, and
+// whether that uid is the image's conventional runner user (1001). Resolution
+// order, highest priority first:
+//
+//  1. --user <uid:gid>      (CLI)
+//  2. --as-runner           (CLI)
+//  3. run_local.user        (job YAML)
+//  4. run_local.as_runner   (job YAML)
+//  5. host uid              (default, legacy behavior)
+//
+// CLI flags override the job YAML so a single invocation can deviate, while the
+// YAML block keeps every flag-less run-local of that job consistent. When the
+// resolved id is the runner uid, asRunner is true and run-local relies on the
+// image's own /etc/passwd and sudoers instead of synthesizing them.
+func resolveRunAsUser(ctx *cli.Context, spec *worker.JobSpec) (uid, gid int, asRunner bool, err error) {
+	var specUser string
+	var specAsRunner bool
+	if spec != nil && spec.RunLocal != nil {
+		specUser = spec.RunLocal.User
+		specAsRunner = spec.RunLocal.AsRunner
+	}
+	return resolveRunAsUserFromArgs(ctx.String("user"), ctx.Bool("as-runner"), specUser, specAsRunner)
+}
+
+// resolveRunAsUserFromArgs is the pure-function core of resolveRunAsUser,
+// extracted so the precedence logic can be unit tested without a cli.Context.
+// When nothing pins a uid it falls back to the host user.
+func resolveRunAsUserFromArgs(userFlag string, asRunnerFlag bool, specUser string, specAsRunner bool) (uid, gid int, asRunner bool, err error) {
+	if asRunnerFlag && userFlag != "" {
+		return 0, 0, false, fmt.Errorf("--as-runner and --user are mutually exclusive")
+	}
+
+	switch {
+	case userFlag != "":
+		uid, gid, err = parseUserGroup(userFlag)
+	case asRunnerFlag:
+		uid, gid = runnerUID, runnerGID
+	case specUser != "":
+		uid, gid, err = parseUserGroup(specUser)
+	case specAsRunner:
+		uid, gid = runnerUID, runnerGID
+	default:
+		uid, gid = hostRunAsUser()
+	}
+	if err != nil {
+		return 0, 0, false, err
+	}
+
+	asRunner = uid == runnerUID && gid == runnerGID
+	return uid, gid, asRunner, nil
+}
+
+// makeWritableFor ensures the container's run-as user can write to a run-local
+// scratch path. It first tries to chown to the target uid/gid — which works
+// when run-local runs as root (e.g. via sudo) or when the target is the host
+// uid. When that fails (an unprivileged run-local can't chown to a foreign uid
+// such as 1001 for --as-runner) it falls back to a world-writable mode so the
+// foreign uid can still write to this throwaway /tmp path.
+func makeWritableFor(path string, uid, gid int) error {
+	if err := os.Chown(path, uid, gid); err != nil {
+		if chmodErr := os.Chmod(path, 0777); chmodErr != nil {
+			return fmt.Errorf("could not chown %s to %d:%d (%v) nor make it world-writable: %w", path, uid, gid, err, chmodErr)
+		}
+	}
+	return nil
+}
+
 // RunLocalCommand executes a job in a container, fulfilling worker behavior.
 // This uses the same JobRunner infrastructure as the worker, ensuring consistent
 // execution between local development and production. Or in outages of some kind.
@@ -106,21 +202,39 @@ var RunLocalCommand = &cli.Command{
 			Name:  "pr",
 			Usage: "GitHub PR number to test. Resolves the head repo and branch via `gh pr view`, then behaves like --code-url / --code-ref. Requires `gh` on PATH and the cwd to be inside a github checkout. Mutually exclusive with --code-url.",
 		},
+		&cli.BoolFlag{
+			Name:  "as-runner",
+			Usage: "Run the job container as the image's runner uid (1001:1001), matching the worker, instead of the host uid. Gives sudo/HOME parity for jobs that rely on the image's runner user (e.g. `sudo apt-get`). Writes to /job are made world-writable since an unprivileged run-local can't chown to 1001. Can also be set per-job via the job YAML's run_local block.",
+		},
+		&cli.StringFlag{
+			Name:  "user",
+			Usage: "User to run the job container as: a numeric uid[:gid] (e.g. \"1001:1001\"), or the symbolic name \"runner\" (image runner uid 1001) or \"host\" (the invoking user). Overrides the host-uid default. Mutually exclusive with --as-runner.",
+		},
 	},
 	Action: runLocalAction,
 }
+
+// runnerUID/runnerGID are the image's conventional runner user. The worker
+// runs jobs as this uid by default (see docker_runner.go), and the runnerbase
+// image creates a `runner` user with this uid plus its sudoers entry. When
+// run-local targets this uid it can lean on the image's own /etc/passwd and
+// sudoers instead of synthesizing them.
+const (
+	runnerUID = 1001
+	runnerGID = 1001
+)
 
 // resolvedCodeSource holds what --code-url / --code-ref / --pr resolve to. A
 // nil value means run-local should fall back to its default behavior of
 // bind-mounting --job-dir at /job/src.
 type resolvedCodeSource struct {
-	URL       string
-	Ref       string
-	HeadRef   string // branch name (== Ref when Ref is a branch; used for HEAD_REF env)
-	BaseURL   string // upstream URL when PR is cross-repo, empty otherwise
-	BaseRef   string // base branch when known
-	PRNumber  int    // 0 when not from --pr
-	IsForkPR  bool
+	URL      string
+	Ref      string
+	HeadRef  string // branch name (== Ref when Ref is a branch; used for HEAD_REF env)
+	BaseURL  string // upstream URL when PR is cross-repo, empty otherwise
+	BaseRef  string // base branch when known
+	PRNumber int    // 0 when not from --pr
+	IsForkPR bool
 }
 
 // resolveCodeSource turns the user's --code-url / --code-ref / --pr flags
@@ -172,11 +286,11 @@ func resolvePRViaGH(prNum int) (*resolvedCodeSource, error) {
 	}
 
 	var pr struct {
-		HeadRefName         string `json:"headRefName"`
-		HeadRefOid          string `json:"headRefOid"`
-		BaseRefName         string `json:"baseRefName"`
-		IsCrossRepository   bool   `json:"isCrossRepository"`
-		HeadRepository      struct {
+		HeadRefName       string `json:"headRefName"`
+		HeadRefOid        string `json:"headRefOid"`
+		BaseRefName       string `json:"baseRefName"`
+		IsCrossRepository bool   `json:"isCrossRepository"`
+		HeadRepository    struct {
 			Name          string `json:"name"`
 			NameWithOwner string `json:"nameWithOwner"`
 		} `json:"headRepository"`
@@ -263,9 +377,21 @@ func cloneCodeSource(src *resolvedCodeSource, uid, gid int) (string, func(), err
 		}
 	}
 
-	// Match ownership to the container's run-as user.
-	_ = filepath.Walk(tmp, func(path string, _ os.FileInfo, _ error) error {
-		_ = os.Chown(path, uid, gid)
+	// Match ownership to the container's run-as user. When run-local is
+	// unprivileged it can't chown to a foreign uid (e.g. 1001 for --as-runner);
+	// in that case add group/other write bits so that uid can still write to
+	// this throwaway clone, preserving existing exec bits (scripts, binaries).
+	_ = filepath.Walk(tmp, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info == nil {
+			return nil
+		}
+		if err := os.Chown(path, uid, gid); err != nil {
+			add := os.FileMode(0066)
+			if info.IsDir() {
+				add = 0077
+			}
+			_ = os.Chmod(path, info.Mode()|add)
+		}
 		return nil
 	})
 	return tmp, cleanup, nil
@@ -371,12 +497,24 @@ func runLocalAction(ctx *cli.Context) error {
 	// Generate a job ID for this execution
 	jobID := uuid.New().String()[:8]
 
+	// Resolve the uid/gid the job container runs as. Default is the host user
+	// (legacy run-local behavior); --as-runner / --user or the job's run_local
+	// block can pin the worker's runner uid (1001) for sudo/HOME parity.
+	uid, gid, asRunner, err := resolveRunAsUser(ctx, spec)
+	if err != nil {
+		return err
+	}
+	if asRunner {
+		fmt.Printf("Run-as user: %d:%d (image runner — worker parity)\n", uid, gid)
+	} else {
+		fmt.Printf("Run-as user: %d:%d (host)\n", uid, gid)
+	}
+
 	// Create temp workspace matching production layout: /job/ with src/ subdir.
-	// The container runs as the host user (see hostRunAsUser below), so chown
-	// the workspace and its src/ to match — otherwise, when run-local is
-	// invoked via sudo, the tmpdir is root-owned and the container can't write
-	// triggers.json, logs, etc.
-	uid, gid := hostRunAsUser()
+	// The container runs as the resolved uid, so make the workspace and its
+	// src/ writable by that uid — otherwise the container can't write
+	// triggers.json, logs, etc. (e.g. when run-local is invoked via sudo, or
+	// when --as-runner pins a uid that doesn't own this tmpdir).
 	tempWorkspace, err := os.MkdirTemp("/tmp", fmt.Sprintf("reactorcide-local-job-%s-", jobID))
 	if err != nil {
 		return fmt.Errorf("failed to create temp workspace: %w", err)
@@ -384,8 +522,8 @@ func runLocalAction(ctx *cli.Context) error {
 	if err := os.Chmod(tempWorkspace, 0755); err != nil {
 		return fmt.Errorf("failed to chmod temp workspace: %w", err)
 	}
-	if err := os.Chown(tempWorkspace, uid, gid); err != nil {
-		return fmt.Errorf("failed to chown temp workspace: %w", err)
+	if err := makeWritableFor(tempWorkspace, uid, gid); err != nil {
+		return fmt.Errorf("failed to prepare temp workspace: %w", err)
 	}
 	defer os.RemoveAll(tempWorkspace)
 
@@ -394,8 +532,8 @@ func runLocalAction(ctx *cli.Context) error {
 	if err := os.MkdirAll(srcSubdir, 0755); err != nil {
 		return fmt.Errorf("failed to create workspace src dir: %w", err)
 	}
-	if err := os.Chown(srcSubdir, uid, gid); err != nil {
-		return fmt.Errorf("failed to chown workspace src dir: %w", err)
+	if err := makeWritableFor(srcSubdir, uid, gid); err != nil {
+		return fmt.Errorf("failed to prepare workspace src dir: %w", err)
 	}
 
 	// Resolve what to mount at /job/src:
@@ -446,48 +584,66 @@ func runLocalAction(ctx *cli.Context) error {
 	jobConfig.SourceDir = srcMount
 	jobConfig.RunAsUser = fmt.Sprintf("%d:%d", uid, gid)
 
-	// Synthesize a minimal /etc/passwd and /etc/group so tools that require a
-	// passwd entry (ssh, sudo, id, etc.) work when the container runs as the
-	// host uid — which rarely matches any user baked into the image. We keep
-	// entries for root and for the image's conventional uid 1001 so references
-	// to /home/reactorcide still resolve.
-	controlDir, err := os.MkdirTemp("/tmp", fmt.Sprintf("reactorcide-local-ctl-%s-", jobID))
-	if err != nil {
-		return fmt.Errorf("failed to create control dir: %w", err)
-	}
-	defer os.RemoveAll(controlDir)
+	// When running as the image's runner uid (--as-runner / --user 1001:1001),
+	// the container already has a real /etc/passwd entry (`runner`, home
+	// /home/runner, owned by 1001 and writable) and the matching sudoers entry,
+	// so we leave them alone and let HOME resolve from the image — exactly what
+	// the worker does. Otherwise we synthesize a minimal /etc/passwd and
+	// /etc/group so tools that require a passwd entry (ssh, sudo, id, etc.)
+	// work when the container runs as a uid that doesn't match any user baked
+	// into the image, plus a writable HOME scratch at /home/runner so ~ is both
+	// writable and the same path the worker uses.
+	if !asRunner {
+		controlDir, err := os.MkdirTemp("/tmp", fmt.Sprintf("reactorcide-local-ctl-%s-", jobID))
+		if err != nil {
+			return fmt.Errorf("failed to create control dir: %w", err)
+		}
+		defer os.RemoveAll(controlDir)
 
-	passwdFile := filepath.Join(controlDir, "passwd")
-	groupFile := filepath.Join(controlDir, "group")
-	passwdContents := fmt.Sprintf(
-		"root:x:0:0:root:/root:/bin/sh\n"+
-			"reactorcide:x:1001:1001:reactorcide:/home/reactorcide:/bin/sh\n"+
-			"local:x:%d:%d:local user:/job:/bin/sh\n",
-		uid, gid,
-	)
-	groupContents := fmt.Sprintf(
-		"root:x:0:\n"+
-			"reactorcide:x:1001:\n"+
-			"local:x:%d:\n",
-		gid,
-	)
-	if err := os.WriteFile(passwdFile, []byte(passwdContents), 0644); err != nil {
-		return fmt.Errorf("failed to write synthetic passwd: %w", err)
-	}
-	if err := os.WriteFile(groupFile, []byte(groupContents), 0644); err != nil {
-		return fmt.Errorf("failed to write synthetic group: %w", err)
-	}
-	jobConfig.ExtraMounts = append(jobConfig.ExtraMounts,
-		fmt.Sprintf("%s:/etc/passwd:ro", passwdFile),
-		fmt.Sprintf("%s:/etc/group:ro", groupFile),
-	)
+		// Writable HOME scratch owned by the run-as (host) uid, mounted at
+		// /home/runner. The image's own /home/runner is owned by 1001 and so
+		// isn't writable by the host uid; this gives a fresh, run-as-uid-owned
+		// HOME the way each container starts with an empty ephemeral home on a
+		// worker.
+		homeDir := filepath.Join(controlDir, "home")
+		if err := os.MkdirAll(homeDir, 0755); err != nil {
+			return fmt.Errorf("failed to create home scratch dir: %w", err)
+		}
+		if err := makeWritableFor(homeDir, uid, gid); err != nil {
+			return fmt.Errorf("failed to prepare home scratch dir: %w", err)
+		}
 
-	// Default HOME to /job so jobs that touch ~ (e.g. mkdir ~/.ssh) work even
-	// when the host uid's passwd entry points at /job (see above). CI runs as
-	// uid 1001 which has /home/reactorcide; local runs as an arbitrary uid so
-	// we anchor ~ to the workspace root.
-	if _, ok := jobConfig.Env["HOME"]; !ok {
-		jobConfig.Env["HOME"] = "/job"
+		passwdFile := filepath.Join(controlDir, "passwd")
+		groupFile := filepath.Join(controlDir, "group")
+		passwdContents := fmt.Sprintf(
+			"root:x:0:0:root:/root:/bin/sh\n"+
+				"reactorcide:x:1001:1001:reactorcide:/home/reactorcide:/bin/sh\n"+
+				"local:x:%d:%d:local user:/home/runner:/bin/sh\n",
+			uid, gid,
+		)
+		groupContents := fmt.Sprintf(
+			"root:x:0:\n"+
+				"reactorcide:x:1001:\n"+
+				"local:x:%d:\n",
+			gid,
+		)
+		if err := os.WriteFile(passwdFile, []byte(passwdContents), 0644); err != nil {
+			return fmt.Errorf("failed to write synthetic passwd: %w", err)
+		}
+		if err := os.WriteFile(groupFile, []byte(groupContents), 0644); err != nil {
+			return fmt.Errorf("failed to write synthetic group: %w", err)
+		}
+		jobConfig.ExtraMounts = append(jobConfig.ExtraMounts,
+			fmt.Sprintf("%s:/etc/passwd:ro", passwdFile),
+			fmt.Sprintf("%s:/etc/group:ro", groupFile),
+			fmt.Sprintf("%s:/home/runner", homeDir),
+		)
+
+		// Default HOME to the writable scratch (matches the worker's
+		// /home/runner). A job that sets HOME explicitly still wins.
+		if _, ok := jobConfig.Env["HOME"]; !ok {
+			jobConfig.Env["HOME"] = "/home/runner"
+		}
 	}
 
 	if dryRun {
@@ -536,6 +692,13 @@ func performLocalDryRun(spec *worker.JobSpec, config *worker.JobConfig, masker *
 	fmt.Printf("  SourceDir: %s\n", config.SourceDir)
 	fmt.Printf("  WorkingDir: %s\n", config.WorkingDir)
 	fmt.Printf("  RunAsUser: %s\n", config.RunAsUser)
+	fmt.Printf("  HOME: %s\n", config.Env["HOME"])
+	if len(config.ExtraMounts) > 0 {
+		fmt.Println("  ExtraMounts:")
+		for _, m := range config.ExtraMounts {
+			fmt.Printf("    - %s\n", m)
+		}
+	}
 
 	fmt.Println("\n--- END DRY RUN ---")
 	return nil

--- a/coordinator_api/cmd/run_local_test.go
+++ b/coordinator_api/cmd/run_local_test.go
@@ -350,6 +350,59 @@ source:
 	}
 }
 
+func TestJobSpec_RunLocalBlock(t *testing.T) {
+	tempDir := t.TempDir()
+	jobFile := filepath.Join(tempDir, "test.yaml")
+
+	content := `name: test-job
+command: echo hello
+run_local:
+  as_runner: true
+  user: "1001:1001"
+`
+	if err := os.WriteFile(jobFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	spec, err := worker.LoadJobSpec(jobFile)
+	if err != nil {
+		t.Fatalf("LoadJobSpec failed: %v", err)
+	}
+	if spec.RunLocal == nil {
+		t.Fatal("expected run_local block to be parsed")
+	}
+	if !spec.RunLocal.AsRunner {
+		t.Error("expected run_local.as_runner=true")
+	}
+	if spec.RunLocal.User != "1001:1001" {
+		t.Errorf("expected run_local.user '1001:1001', got %q", spec.RunLocal.User)
+	}
+}
+
+func TestMergeJobSpecs_RunLocalOverlay(t *testing.T) {
+	base := &worker.JobSpec{
+		Name:     "base",
+		Command:  "echo hi",
+		RunLocal: &worker.RunLocalSpec{AsRunner: true},
+	}
+	overlay := &worker.JobSpec{
+		RunLocal: &worker.RunLocalSpec{User: "5000:5000"},
+	}
+
+	merged, _ := worker.MergeJobSpecs(base, []*worker.JobSpec{overlay}, []string{"overlay.yaml"})
+	if merged.RunLocal == nil {
+		t.Fatal("expected run_local to survive merge")
+	}
+	if merged.RunLocal.User != "5000:5000" {
+		t.Errorf("expected overlay to override user, got %q", merged.RunLocal.User)
+	}
+	// Base run_local with no overlay should pass through unchanged.
+	mergedNoOverlay, _ := worker.MergeJobSpecs(base, nil, nil)
+	if mergedNoOverlay.RunLocal == nil || !mergedNoOverlay.RunLocal.AsRunner {
+		t.Error("expected base run_local.as_runner to pass through merge")
+	}
+}
+
 func TestResolveCodeSourceFromArgs(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -418,6 +471,130 @@ func TestResolveCodeSourceFromArgs(t *testing.T) {
 			}
 			if got.HeadRef != tt.wantHeadRef {
 				t.Errorf("HeadRef = %q, want %q", got.HeadRef, tt.wantHeadRef)
+			}
+		})
+	}
+}
+
+func TestParseUserGroup(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantUID int
+		wantGID int
+		wantErr bool
+	}{
+		{"1001:1001", 1001, 1001, false},
+		{"1001", 1001, 1001, false},
+		{"5000:6000", 5000, 6000, false},
+		{" 1001 : 1001 ", 1001, 1001, false},
+		{"1001:", 1001, 1001, false},
+		{"runner", runnerUID, runnerGID, false},
+		{"RUNNER", runnerUID, runnerGID, false},
+		{"abc", 0, 0, true},
+		{"1001:xyz", 0, 0, true},
+		{"", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			uid, gid, err := parseUserGroup(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if uid != tt.wantUID || gid != tt.wantGID {
+				t.Errorf("parseUserGroup(%q) = %d:%d, want %d:%d", tt.input, uid, gid, tt.wantUID, tt.wantGID)
+			}
+		})
+	}
+}
+
+func TestResolveRunAsUserFromArgs(t *testing.T) {
+	hostUID, hostGID := hostRunAsUser()
+
+	tests := []struct {
+		name         string
+		userFlag     string
+		asRunnerFlag bool
+		specUser     string
+		specAsRunner bool
+		wantUID      int
+		wantGID      int
+		wantAsRunner bool
+		wantErr      bool
+	}{
+		{
+			name:    "default falls back to host uid",
+			wantUID: hostUID, wantGID: hostGID, wantAsRunner: false,
+		},
+		{
+			name: "as-runner flag pins 1001", asRunnerFlag: true,
+			wantUID: runnerUID, wantGID: runnerGID, wantAsRunner: true,
+		},
+		{
+			name: "user flag pins explicit uid", userFlag: "5000:6000",
+			wantUID: 5000, wantGID: 6000, wantAsRunner: false,
+		},
+		{
+			name: "user flag 1001 is treated as runner", userFlag: "1001:1001",
+			wantUID: runnerUID, wantGID: runnerGID, wantAsRunner: true,
+		},
+		{
+			name: "yaml as_runner applies when no flags", specAsRunner: true,
+			wantUID: runnerUID, wantGID: runnerGID, wantAsRunner: true,
+		},
+		{
+			name: "yaml user applies when no flags", specUser: "1001:1001",
+			wantUID: runnerUID, wantGID: runnerGID, wantAsRunner: true,
+		},
+		{
+			name: "yaml symbolic user runner", specUser: "runner",
+			wantUID: runnerUID, wantGID: runnerGID, wantAsRunner: true,
+		},
+		{
+			name: "symbolic user host resolves to host uid", userFlag: "host",
+			wantUID: hostUID, wantGID: hostGID, wantAsRunner: false,
+		},
+		{
+			name: "cli user overrides yaml", userFlag: "5000:5000", specAsRunner: true,
+			wantUID: 5000, wantGID: 5000, wantAsRunner: false,
+		},
+		{
+			name: "cli as-runner overrides yaml user", asRunnerFlag: true, specUser: "5000:5000",
+			wantUID: runnerUID, wantGID: runnerGID, wantAsRunner: true,
+		},
+		{
+			name: "as-runner and user together error", asRunnerFlag: true, userFlag: "1001:1001",
+			wantErr: true,
+		},
+		{
+			name: "invalid user flag errors", userFlag: "nope",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uid, gid, asRunner, err := resolveRunAsUserFromArgs(tt.userFlag, tt.asRunnerFlag, tt.specUser, tt.specAsRunner)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if uid != tt.wantUID || gid != tt.wantGID {
+				t.Errorf("uid:gid = %d:%d, want %d:%d", uid, gid, tt.wantUID, tt.wantGID)
+			}
+			if asRunner != tt.wantAsRunner {
+				t.Errorf("asRunner = %v, want %v", asRunner, tt.wantAsRunner)
 			}
 		})
 	}

--- a/coordinator_api/internal/worker/job_spec.go
+++ b/coordinator_api/internal/worker/job_spec.go
@@ -65,6 +65,26 @@ type JobSpec struct {
 	// execute jobs with this set — used for jobs that fundamentally need CI
 	// state (PR diff base, push-back-to-remote with a PAT, etc.).
 	DisableRunLocal bool `json:"disable_run_local" yaml:"disable_run_local"`
+
+	// RunLocal holds settings that only affect `reactorcide run-local`. The
+	// worker ignores this block entirely (ToJobConfig never reads it), so it's
+	// the place to pin local-only behavior — e.g. the container uid — without
+	// changing how the job runs in CI. Defining it here makes a job behave
+	// consistently across local invocations without per-command flags.
+	RunLocal *RunLocalSpec `json:"run_local" yaml:"run_local"`
+}
+
+// RunLocalSpec holds run-local-only overrides. The worker never reads this;
+// it exists so a job can declare how it should be executed on a laptop.
+type RunLocalSpec struct {
+	// AsRunner runs the job container as the image's conventional runner uid
+	// (1001:1001), matching the worker, instead of the host uid. This gives
+	// sudo and HOME parity for jobs that rely on the image's runner user.
+	AsRunner bool `json:"as_runner" yaml:"as_runner"`
+
+	// User pins an explicit uid[:gid] for the job container (e.g. "1001:1001").
+	// Takes precedence over AsRunner when both are set. Empty means unset.
+	User string `json:"user" yaml:"user"`
 }
 
 // SourceSpec defines source code preparation
@@ -556,6 +576,14 @@ func MergeJobSpecs(base *JobSpec, overlays []*JobSpec, overlayFiles []string) (*
 		}
 	}
 
+	// Deep copy run-local block
+	if base.RunLocal != nil {
+		result.RunLocal = &RunLocalSpec{
+			AsRunner: base.RunLocal.AsRunner,
+			User:     base.RunLocal.User,
+		}
+	}
+
 	var secretOverrides []SecretOverride
 
 	// Apply each overlay in order
@@ -619,6 +647,14 @@ func MergeJobSpecs(base *JobSpec, overlays []*JobSpec, overlayFiles []string) (*
 				URL:  overlay.Source.URL,
 				Ref:  overlay.Source.Ref,
 				Path: overlay.Source.Path,
+			}
+		}
+
+		// Override run-local block if set in overlay
+		if overlay.RunLocal != nil {
+			result.RunLocal = &RunLocalSpec{
+				AsRunner: overlay.RunLocal.AsRunner,
+				User:     overlay.RunLocal.User,
 			}
 		}
 	}


### PR DESCRIPTION
Basically it was difficult to have options for jobs that need uid options for some bits to be closer to how they'll run in an API run, but we don't want to make that too complicated for the usual case of mounting local files into the job.